### PR TITLE
Tests files moved to tests folders

### DIFF
--- a/src/components/schedule-visualizer/door/tests/door.test.tsx
+++ b/src/components/schedule-visualizer/door/tests/door.test.tsx
@@ -2,9 +2,9 @@ import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import { createMount } from '@material-ui/core/test-utils';
 import { ReactWrapper } from 'enzyme';
 import React from 'react';
-import SingleHingeDoor from './door-single-hinge';
-import SingleSlideDoor from './door-single-slide';
-import DefaultDoor from './door-default';
+import SingleHingeDoor from '../door-single-hinge';
+import SingleSlideDoor from '../door-single-slide';
+import DefaultDoor from '../door-default';
 
 const mainDoor = {
   name: 'main_door',

--- a/src/components/schedule-visualizer/tests/arrow.test.tsx
+++ b/src/components/schedule-visualizer/tests/arrow.test.tsx
@@ -1,7 +1,7 @@
 import { createMount } from '@material-ui/core/test-utils';
 import React from 'react';
-import { UpArrow, DownArrow } from './arrow';
-import { Arrow } from './arrow';
+import { UpArrow, DownArrow } from '../arrow';
+import { Arrow } from '../arrow';
 
 const mount = createMount();
 

--- a/src/components/schedule-visualizer/tests/lift.test.tsx
+++ b/src/components/schedule-visualizer/tests/lift.test.tsx
@@ -1,8 +1,8 @@
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
-import fakeLiftStates from '../../mock/data/lift-states';
-import getBuildingMap from '../../mock/data/building-map';
-import Lift from './lift';
+import fakeLiftStates from '../../../mock/data/lift-states';
+import getBuildingMap from '../../../mock/data/building-map';
+import Lift from '../lift';
 import React from 'react';
 
 const mount = createMount();

--- a/src/components/schedule-visualizer/tests/place.test.tsx
+++ b/src/components/schedule-visualizer/tests/place.test.tsx
@@ -1,7 +1,7 @@
 import { createMount } from '@material-ui/core/test-utils';
 import React from 'react';
-import getBuildingMap from '../../mock/data/building-map';
-import Place from './place';
+import getBuildingMap from '../../../mock/data/building-map';
+import Place from '../place';
 
 const mount = createMount();
 

--- a/src/components/schedule-visualizer/tests/robot-trajectory.test.tsx
+++ b/src/components/schedule-visualizer/tests/robot-trajectory.test.tsx
@@ -1,7 +1,7 @@
 import { createMount } from '@material-ui/core/test-utils';
 import React from 'react';
-import FakeTrajectoryManager from '../../mock/fake-traj-manager';
-import RobotTrajectory from './robot-trajectory';
+import FakeTrajectoryManager from '../../../mock/fake-traj-manager';
+import RobotTrajectory from '../robot-trajectory';
 
 const mount = createMount();
 

--- a/src/components/schedule-visualizer/tests/robot.test.tsx
+++ b/src/components/schedule-visualizer/tests/robot.test.tsx
@@ -1,8 +1,8 @@
 import { createMount } from '@material-ui/core/test-utils';
 import React from 'react';
-import getFleets from '../../mock/data/fleets';
-import ColorManager from './colors';
-import Robot from './robot';
+import getFleets from '../../../mock/data/fleets';
+import ColorManager from '../colors';
+import Robot from '../robot';
 
 const mount = createMount();
 

--- a/src/components/tests/app.test.tsx
+++ b/src/components/tests/app.test.tsx
@@ -2,13 +2,13 @@ import { createMount } from '@material-ui/core/test-utils';
 import { ReactWrapper } from 'enzyme';
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import appConfig from '../app-config';
-import App from './app';
+import appConfig from '../../app-config';
+import App from '../app';
 
 const mount = createMount();
 
 // react-leaflet doesn't work well in jsdom.
-jest.mock('./schedule-visualizer', () => () => null);
+jest.mock('./../schedule-visualizer', () => () => null);
 
 it('renders without crashing', async () => {
   URL.createObjectURL = jest.fn();

--- a/src/components/tests/dispenser-item.test.tsx
+++ b/src/components/tests/dispenser-item.test.tsx
@@ -1,12 +1,10 @@
-import {
-  ListItem,
-} from '@material-ui/core';
+import { ListItem } from '@material-ui/core';
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import fakeDispenserStates from '../mock/data/dispenser-states';
-import DispenserItem from './dispenser-item';
-import DispenserPanel from './dispensers-panel';
+import fakeDispenserStates from '../../mock/data/dispenser-states';
+import DispenserItem from '../dispenser-item';
+import DispenserPanel from '../dispensers-panel';
 
 const mount = createMount();
 
@@ -17,7 +15,7 @@ beforeEach(() => {
 });
 
 it('lists dispensers queued requests ID', () => {
-  Object.keys(dispenserStates).map( (guid, index) => {
+  Object.keys(dispenserStates).map((guid, index) => {
     const state = dispenserStates[guid];
 
     const root = mount(<DispenserItem dispenserState={state} />);

--- a/src/components/tests/dispensers-panel.test.tsx
+++ b/src/components/tests/dispensers-panel.test.tsx
@@ -1,9 +1,9 @@
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import fakeDispenserStates from '../mock/data/dispenser-states';
-import DispenserItem from './dispenser-item';
-import DispenserPanel from './dispensers-panel';
+import fakeDispenserStates from '../../mock/data/dispenser-states';
+import DispenserItem from '../dispenser-item';
+import DispenserPanel from '../dispensers-panel';
 
 const mount = createMount();
 

--- a/src/components/tests/door-item.test.tsx
+++ b/src/components/tests/door-item.test.tsx
@@ -1,9 +1,9 @@
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import buildingMap from '../mock/data/building-map';
-import fakeDoorStates from '../mock/data/door-states';
-import DoorItem from './door-item';
+import buildingMap from '../../mock/data/building-map';
+import fakeDoorStates from '../../mock/data/door-states';
+import DoorItem from '../door-item';
 
 const mount = createMount();
 

--- a/src/components/tests/doors-panel.test.tsx
+++ b/src/components/tests/doors-panel.test.tsx
@@ -1,11 +1,11 @@
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import buildingMap from '../mock/data/building-map';
-import fakeDoorStates from '../mock/data/door-states';
-import FakeTransport from '../mock/fake-transport';
-import DoorItem from './door-item';
-import DoorsPanel from './doors-panel';
+import buildingMap from '../../mock/data/building-map';
+import fakeDoorStates from '../../mock/data/door-states';
+import FakeTransport from '../../mock/fake-transport';
+import DoorItem from '../door-item';
+import DoorsPanel from '../doors-panel';
 
 const mount = createMount();
 

--- a/src/components/tests/lift-item.test.tsx
+++ b/src/components/tests/lift-item.test.tsx
@@ -2,9 +2,9 @@ import { MenuItem } from '@material-ui/core';
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import buildingMap from '../mock/data/building-map';
-import fakeLiftStates from '../mock/data/lift-states';
-import { LiftItem } from './lift-item';
+import buildingMap from '../../mock/data/building-map';
+import fakeLiftStates from '../../mock/data/lift-states';
+import { LiftItem } from '../lift-item';
 
 const mount = createMount();
 

--- a/src/components/tests/lifts-panel.test.tsx
+++ b/src/components/tests/lifts-panel.test.tsx
@@ -2,11 +2,11 @@ import { MenuItem } from '@material-ui/core';
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import buildingMap from '../mock/data/building-map';
-import fakeLiftStates from '../mock/data/lift-states';
-import FakeTransport from '../mock/fake-transport';
-import { LiftItem } from './lift-item';
-import LiftsPanel from './lifts-panel';
+import buildingMap from '../../mock/data/building-map';
+import fakeLiftStates from '../../mock/data/lift-states';
+import FakeTransport from '../../mock/fake-transport';
+import { LiftItem } from '../lift-item';
+import LiftsPanel from '../lifts-panel';
 
 const mount = createMount();
 

--- a/src/components/tests/main-menu.test.tsx
+++ b/src/components/tests/main-menu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import MainMenu from './main-menu';
+import MainMenu from '../main-menu';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/tests/places-panel.test.tsx
+++ b/src/components/tests/places-panel.test.tsx
@@ -1,9 +1,9 @@
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import buildingMap from '../mock/data/building-map';
-import { PlaceItem } from './place-item';
-import PlacesPanel from './places-panel';
+import buildingMap from '../../mock/data/building-map';
+import { PlaceItem } from '../place-item';
+import PlacesPanel from '../places-panel';
 
 const mount = createMount();
 

--- a/src/components/tests/robots-panel.test.tsx
+++ b/src/components/tests/robots-panel.test.tsx
@@ -2,9 +2,9 @@ import { ExpansionPanelDetails, ExpansionPanelSummary } from '@material-ui/core'
 import { createMount } from '@material-ui/core/test-utils';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
-import fakeFleets from '../mock/data/fleets';
-import RobotItem from './robot-item';
-import RobotsPanel from './robots-panel';
+import fakeFleets from '../../mock/data/fleets';
+import RobotItem from '../robot-item';
+import RobotsPanel from '../robots-panel';
 
 const mount = createMount();
 


### PR DESCRIPTION
Requires #20 to be merged first.

Fixes #22

Move tests files of the `components` folder to `components/tests/ ` and tests of `/components/schedule-visualizer`/ to `/components/schedule-visualizer/tests/`