### PR TITLE
Fix for dashboard does not start after PR#21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,9 +1363,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@osrf/romi-js-core-interfaces": {
-      "version": "0.0.2-alpha.5",
-      "resolved": "https://registry.npmjs.org/@osrf/romi-js-core-interfaces/-/romi-js-core-interfaces-0.0.2-alpha.5.tgz",
-      "integrity": "sha512-FTVkl8DHaGWQnOvih8tBsWbvigGOTnTKdFhQIhgbTw7Ovv7ITilcvyxcjjP0bZbH5S9CZHT7jQ7zrWoHnf3HLQ==",
+      "version": "0.0.2-alpha.7",
+      "resolved": "https://registry.npmjs.org/@osrf/romi-js-core-interfaces/-/romi-js-core-interfaces-0.0.2-alpha.7.tgz",
+      "integrity": "sha512-p5RnP9Q56mhjI0t03E5p7ydHPmGzbnqfLySNIs/WRexf+nDp4J2KsqYpOo+mEenxWNHMwmw3b0C1oG4CP01/vw==",
       "requires": {
         "eventemitter3": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@material-ui/core": "^4.9.4",
     "@material-ui/icons": "^4.9.1",
-    "@osrf/romi-js-core-interfaces": "0.0.2-alpha.5",
+    "@osrf/romi-js-core-interfaces": "0.0.2-alpha.7",
     "@osrf/romi-js-soss-transport": "0.0.2-alpha.4",
     "@types/debug": "^4.1.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",

--- a/src/components/schedule-visualizer/door/door-double-hinge.tsx
+++ b/src/components/schedule-visualizer/door/door-double-hinge.tsx
@@ -17,15 +17,15 @@ const DoubleHingeDoor = function(props: DoorProps): React.ReactElement {
   return (
     <>
       <SingleHingeDoor
-        v1={[hingeX1, -hingeY1]}
-        v2={[extendX1, -extendY1]}
+        v1={[hingeX1, hingeY1]}
+        v2={[extendX1, extendY1]}
         door={door}
         onClick={onClick}
         currentMode={currentMode}
       />
       <SingleHingeDoor
-        v1={[extendX1, -extendY1]}
-        v2={[hingeX2, -hingeY2]}
+        v1={[extendX1, extendY1]}
+        v2={[hingeX2, hingeY2]}
         door={door}
         onClick={onClick}
         currentMode={currentMode}

--- a/src/components/schedule-visualizer/door/door-double-slide.tsx
+++ b/src/components/schedule-visualizer/door/door-double-slide.tsx
@@ -17,15 +17,15 @@ const DoubleSlideDoor = function(props: DoorProps): React.ReactElement {
   return (
     <>
       <SingleSlideDoor
-        v1={[hingeX1, -hingeY1]}
-        v2={[extendX1, -extendY1]}
+        v1={[hingeX1, hingeY1]}
+        v2={[extendX1, extendY1]}
         door={door}
         onClick={onClick}
         currentMode={currentMode}
       />
       <SingleSlideDoor
-        v1={[extendX1, -extendY1]}
-        v2={[hingeX2, -hingeY2]}
+        v1={[extendX1, extendY1]}
+        v2={[hingeX2, hingeY2]}
         door={door}
         onClick={onClick}
         currentMode={currentMode}

--- a/src/components/schedule-visualizer/lift.tsx
+++ b/src/components/schedule-visualizer/lift.tsx
@@ -3,6 +3,7 @@ import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
 import Door from './door/door';
 import { UpArrow, DownArrow } from './arrow';
+import { radiansToDegrees } from '../../util/angle-calculation';
 
 export interface LiftProps {
   currentFloor: string;
@@ -134,7 +135,7 @@ const Lift = React.forwardRef(function(
           y={contextTopVerticeY}
           rx="0.1"
           ry="0.1"
-          transform={`rotate(${ref_yaw},${x},${contextY})`}
+          transform={`rotate(${radiansToDegrees(ref_yaw)}, ${x},${contextY})`}
         />
         {liftMotionText && (
           <text id="liftMotion" className={classes.liftText} x={x} y={contextY}>

--- a/src/e2e-tests/soss.yaml
+++ b/src/e2e-tests/soss.yaml
@@ -5,7 +5,7 @@ systems:
     port: 50001
     cert: .rmf/certs/websocket_server.crt
     key: .rmf/certs/websocket_server.key
-    authentication: { policies: [ { secret: rmf, algo: HS256 } ] }
+    authentication: { policies: [{ secret: rmf, algo: HS256 }] }
 
   # ROS2 node
   ros2: { type: ros2 }
@@ -16,11 +16,12 @@ routes:
   ros2_service: { server: ros2, clients: client }
 
 topics:
-  door_states: { type: "rmf_door_msgs/DoorState", route: ros2_to_client }
-  door_requests: { type: "rmf_door_msgs/DoorRequest", route: client_to_ros2 }
-  lift_states: { type: "rmf_lift_msgs/LiftState", route: ros2_to_client }
-  lift_requests: { type: "rmf_lift_msgs/LiftRequest", route: client_to_ros2 }
-  fleet_states: { type: "rmf_fleet_msgs/FleetState", route: ros2_to_client }
+  door_states: { type: 'rmf_door_msgs/DoorState', route: ros2_to_client }
+  door_requests: { type: 'rmf_door_msgs/DoorRequest', route: client_to_ros2 }
+  lift_states: { type: 'rmf_lift_msgs/LiftState', route: ros2_to_client }
+  lift_requests: { type: 'rmf_lift_msgs/LiftRequest', route: client_to_ros2 }
+  fleet_states: { type: 'rmf_fleet_msgs/FleetState', route: ros2_to_client }
+  dispenser_states: { type: 'rmf_dispenser_msgs/DispenserState', route: ros2_to_client }
 
 services:
-  get_building_map: { type: "building_map_msgs/GetBuildingMap", route: ros2_service }
+  get_building_map: { type: 'building_map_msgs/GetBuildingMap', route: ros2_service }

--- a/src/util/angle-calculation.ts
+++ b/src/util/angle-calculation.ts
@@ -1,0 +1,4 @@
+export function radiansToDegrees(radians: number) {
+    var pi = Math.PI;
+    return radians * (180 / pi);
+}


### PR DESCRIPTION
Fixes #28 
Updated `romi-js-core-interfaces` to **"0.0.2-alpha.7"** and added `dispenser_states` on soss config