### PR TITLE
Improved lift UX #30

### DIFF
--- a/src/components/schedule-visualizer/lift.tsx
+++ b/src/components/schedule-visualizer/lift.tsx
@@ -27,21 +27,21 @@ const getLiftStyle = (classes: any, currentMode: number | undefined, isInCurrent
     MODE_OFFLINE,
     MODE_UNKNOWN,
   } = RomiCore.LiftState;
-  const isOffLine = currentMode === MODE_OFFLINE || currentMode === MODE_UNKNOWN;
   const isModeAGV = currentMode === MODE_AGV;
   const isModeHuman = currentMode === MODE_HUMAN;
 
   if (currentMode === MODE_EMERGENCY) return classes.emergency;
   if (currentMode === MODE_FIRE) return classes.fire;
-  if (isOffLine) return classes.offLine;
-  if (!isInCurrentFloor) return classes.liftOnAnotherFloor;
+  if (currentMode === MODE_OFFLINE) return classes.offLine;
+  if (currentMode === MODE_UNKNOWN) return classes.unknownlift;
+  if (!isInCurrentFloor) return classes.liftMoving;
   if (isInCurrentFloor && isModeAGV) return classes.liftOnCurrentFloor;
   if (isInCurrentFloor && isModeHuman) return classes.humanMode;
 };
 
 // Gets the text to insert to the lift, the text depend on the current mode, motion state and the
 // current and destination floor of the lift.
-const getLiftModeText = (currentMode: number | undefined) => {
+const getLiftModeText = (currentMode: number | undefined, currentFloor: string | undefined) => {
   const {
     MODE_AGV,
     MODE_EMERGENCY,
@@ -50,13 +50,13 @@ const getLiftModeText = (currentMode: number | undefined) => {
     MODE_OFFLINE,
     MODE_UNKNOWN,
   } = RomiCore.LiftState;
-  if (!currentMode) return 'UNKNOWN';
+  if (!currentMode) return !!currentFloor ? `Floor: ${currentFloor}` : 'UNKNOWN';
   if (currentMode === MODE_FIRE) return 'FIRE!';
   if (currentMode === MODE_EMERGENCY) return 'EMERGENCY!';
   if (currentMode === MODE_OFFLINE) return 'OFFLINE';
   if (currentMode === MODE_HUMAN) return 'HUMAN';
   if (currentMode === MODE_AGV) return 'AGV';
-  if (currentMode === MODE_UNKNOWN) return 'UNKNOWN';
+  if (currentMode === MODE_UNKNOWN) return !!currentFloor ? `Floor: ${currentFloor}` : 'UNKNOWN';
 };
 
 const getLiftMotionText = (
@@ -66,7 +66,7 @@ const getLiftMotionText = (
 ) => {
   const { MOTION_DOWN, MOTION_UP, MOTION_STOPPED, MOTION_UNKNOWN } = RomiCore.LiftState;
   if (motionState === MOTION_UNKNOWN) return '?';
-  if (motionState === MOTION_STOPPED) return 'STOPPED';
+  if (motionState === MOTION_STOPPED) return !!currentFloor ? currentFloor : 'STOPPED';
   if (motionState === MOTION_UP || motionState === MOTION_DOWN)
     return `${currentFloor} → ${destinationFloor}`;
 };
@@ -77,22 +77,16 @@ const getLiftMotionText = (
 const transformMiddleCoordsOfRectToSVGBeginPoint = (
   x: number,
   y: number,
-  width: number | undefined,
-  depth: number | undefined,
+  width: number,
+  depth: number,
 ) => {
-  // TODO: the width and height should be not undefined we addressed this
-  // https://github.com/osrf/romi-js-core-interfaces/issues/4
-  if (!width || !depth) throw new Error('Width and Height cannot be undefined');
   return { x: x - width / 2, y: y + depth / 2 };
 };
 
 /**
  * Get related Y coord starting from top to bottom.
  */
-const getRelatedYCoord = (topY: number, height: number | undefined, percentage: number) => {
-  // TODO: the height should be not undefined we addressed this
-  // https://github.com/osrf/romi-js-core-interfaces/issues/4
-  if (!height) throw new Error('Height cannot be undefined');
+const getRelatedYCoord = (topY: number, height: number, percentage: number) => {
   return topY + height * percentage;
 };
 
@@ -123,7 +117,7 @@ const Lift = React.forwardRef(function(
 
   const liftStyle = getLiftStyle(classes, currentMode, isInCurrentFloor);
   const liftMotionText = getLiftMotionText(liftState?.current_floor, destinationFloor, motionState);
-  const liftModeText = getLiftModeText(currentMode);
+  const liftModeText = getLiftModeText(currentMode, liftState?.current_floor);
   return (
     <>
       <g ref={ref} onClick={e => onClick && onClick(e, lift)}>
@@ -138,17 +132,17 @@ const Lift = React.forwardRef(function(
           transform={`rotate(${radiansToDegrees(ref_yaw)}, ${x},${contextY})`}
         />
         {liftMotionText && (
-          <text id="liftMotion" className={classes.liftText} x={x} y={contextY}>
-            {liftMotionText}
-          </text>
-        )}
-        {liftModeText && (
           <text
-            id="liftMode"
+            id="liftMotion"
             className={classes.liftText}
             x={x}
             y={getRelatedYCoord(contextTopVerticeY, depth, 0.25)}
           >
+            {liftMotionText}
+          </text>
+        )}
+        {liftModeText && (
+          <text id="liftMode" className={classes.liftText} x={x} y={contextY}>
             {liftModeText}
           </text>
         )}
@@ -180,8 +174,12 @@ const useStyles = makeStyles(() => ({
     fill: 'green',
     opacity: '70%',
   },
-  liftOnAnotherFloor: {
+  liftMoving: {
     fill: 'grey',
+    opacity: '70%',
+  },
+  unknownlift: {
+    fill: '#3d3c3c',
     opacity: '80%',
   },
   emergency: {

--- a/src/components/schedule-visualizer/lift.tsx
+++ b/src/components/schedule-visualizer/lift.tsx
@@ -33,10 +33,10 @@ const getLiftStyle = (classes: any, currentMode: number | undefined, isInCurrent
   if (currentMode === MODE_EMERGENCY) return classes.emergency;
   if (currentMode === MODE_FIRE) return classes.fire;
   if (currentMode === MODE_OFFLINE) return classes.offLine;
-  if (!isInCurrentFloor) return classes.liftMoving;
   if (isInCurrentFloor && isModeAGV) return classes.liftOnCurrentFloor;
   if (isInCurrentFloor && isModeHuman) return classes.humanMode;
-  if (isInCurrentFloor && currentMode === MODE_UNKNOWN) return classes.unknownlift;
+  if (isInCurrentFloor && currentMode === MODE_UNKNOWN) return classes.unknownLift;
+  if (!isInCurrentFloor) return classes.liftMoving;
 };
 
 // Gets the text to insert to the lift, the text depend on the current mode, motion state and the
@@ -168,7 +168,7 @@ const useStyles = makeStyles(() => ({
     fill: 'grey',
     opacity: '70%',
   },
-  unknownlift: {
+  unknownLift: {
     fill: '#3d3c3c',
     opacity: '80%',
   },

--- a/src/components/schedule-visualizer/lift.tsx
+++ b/src/components/schedule-visualizer/lift.tsx
@@ -33,30 +33,19 @@ const getLiftStyle = (classes: any, currentMode: number | undefined, isInCurrent
   if (currentMode === MODE_EMERGENCY) return classes.emergency;
   if (currentMode === MODE_FIRE) return classes.fire;
   if (currentMode === MODE_OFFLINE) return classes.offLine;
-  if (currentMode === MODE_UNKNOWN) return classes.unknownlift;
   if (!isInCurrentFloor) return classes.liftMoving;
   if (isInCurrentFloor && isModeAGV) return classes.liftOnCurrentFloor;
   if (isInCurrentFloor && isModeHuman) return classes.humanMode;
+  if (isInCurrentFloor && currentMode === MODE_UNKNOWN) return classes.unknownlift;
 };
 
 // Gets the text to insert to the lift, the text depend on the current mode, motion state and the
 // current and destination floor of the lift.
-const getLiftModeText = (currentMode: number | undefined, currentFloor: string | undefined) => {
-  const {
-    MODE_AGV,
-    MODE_EMERGENCY,
-    MODE_FIRE,
-    MODE_HUMAN,
-    MODE_OFFLINE,
-    MODE_UNKNOWN,
-  } = RomiCore.LiftState;
-  if (!currentMode) return !!currentFloor ? `Floor: ${currentFloor}` : 'UNKNOWN';
+const getLiftModeText = (currentMode: number | undefined) => {
+  const { MODE_EMERGENCY, MODE_FIRE, MODE_OFFLINE } = RomiCore.LiftState;
   if (currentMode === MODE_FIRE) return 'FIRE!';
   if (currentMode === MODE_EMERGENCY) return 'EMERGENCY!';
   if (currentMode === MODE_OFFLINE) return 'OFFLINE';
-  if (currentMode === MODE_HUMAN) return 'HUMAN';
-  if (currentMode === MODE_AGV) return 'AGV';
-  if (currentMode === MODE_UNKNOWN) return !!currentFloor ? `Floor: ${currentFloor}` : 'UNKNOWN';
 };
 
 const getLiftMotionText = (
@@ -69,6 +58,7 @@ const getLiftMotionText = (
   if (motionState === MOTION_STOPPED) return !!currentFloor ? currentFloor : 'STOPPED';
   if (motionState === MOTION_UP || motionState === MOTION_DOWN)
     return `${currentFloor} → ${destinationFloor}`;
+  return 'Floor: ?';
 };
 
 /**
@@ -117,7 +107,7 @@ const Lift = React.forwardRef(function(
 
   const liftStyle = getLiftStyle(classes, currentMode, isInCurrentFloor);
   const liftMotionText = getLiftMotionText(liftState?.current_floor, destinationFloor, motionState);
-  const liftModeText = getLiftModeText(currentMode, liftState?.current_floor);
+  const liftModeText = getLiftModeText(currentMode);
   return (
     <>
       <g ref={ref} onClick={e => onClick && onClick(e, lift)}>

--- a/src/components/schedule-visualizer/tests/lift.test.tsx
+++ b/src/components/schedule-visualizer/tests/lift.test.tsx
@@ -99,7 +99,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     state.current_floor = 'L1';
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(humanMode)-(\d+)/)).toBe(true);
-    expect(wrapper.find('#liftMotion').text()).toEqual('STOPPED');
+    expect(wrapper.find('#liftMotion').text()).toEqual('L1');
     expect(wrapper.find('#liftMode').text()).toEqual('HUMAN');
     wrapper.unmount();
   });
@@ -110,7 +110,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     state.current_floor = 'L1';
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(liftOnCurrentFloor)-(\d+)/)).toBe(true);
-    expect(wrapper.find('#liftMotion').text()).toEqual('STOPPED');
+    expect(wrapper.find('#liftMotion').text()).toEqual('L1');
     expect(wrapper.find('#liftMode').text()).toEqual('AGV');
     wrapper.unmount();
   });

--- a/src/components/schedule-visualizer/tests/lift.test.tsx
+++ b/src/components/schedule-visualizer/tests/lift.test.tsx
@@ -100,7 +100,6 @@ describe('Checks assignation of styles on combination of motion states and mode 
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(humanMode)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual('L1');
-    expect(wrapper.find('#liftMode').text()).toEqual('HUMAN');
     wrapper.unmount();
   });
 
@@ -111,7 +110,6 @@ describe('Checks assignation of styles on combination of motion states and mode 
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(liftOnCurrentFloor)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual('L1');
-    expect(wrapper.find('#liftMode').text()).toEqual('AGV');
     wrapper.unmount();
   });
 

--- a/src/components/schedule-visualizer/tests/lift.test.tsx
+++ b/src/components/schedule-visualizer/tests/lift.test.tsx
@@ -121,7 +121,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     state.destination_floor = 'L4';
     state.motion_state = RomiCore.LiftState.MOTION_UP;
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
-    expect(liftSVGRect.hasClass(/(makeStyles)-(liftOnAnotherFloor)-(\d+)/)).toBe(true);
+    expect(liftSVGRect.hasClass(/(makeStyles)-(liftMoving)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual('L3 → L4');
     wrapper.unmount();
   });
@@ -132,7 +132,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     state.destination_floor = 'L2';
     state.motion_state = RomiCore.LiftState.MOTION_DOWN;
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
-    expect(liftSVGRect.hasClass(/(makeStyles)-(liftOnAnotherFloor)-(\d+)/)).toBe(true);
+    expect(liftSVGRect.hasClass(/(makeStyles)-(liftMoving)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual(`L4 → L2`);
     wrapper.unmount();
   });

--- a/src/components/schedule-visualizer/tests/lift.test.tsx
+++ b/src/components/schedule-visualizer/tests/lift.test.tsx
@@ -56,7 +56,7 @@ describe('Checks assignation of styles on different mode of the Lift', () => {
     return { lift, state };
   };
 
-  test('Check red color and _Fire_ text when the lift its on Fire mode', async () => {
+  test('Check orange color and _Fire_ text when the lift its on Fire mode', async () => {
     const { lift, state } = await loadLift();
     state.current_mode = RomiCore.LiftState.MODE_FIRE;
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
@@ -82,6 +82,15 @@ describe('Checks assignation of styles on different mode of the Lift', () => {
     expect(wrapper.find('#liftMode').text()).toEqual('OFFLINE');
     wrapper.unmount();
   });
+
+  test('Lift on Unknown mode', async () => {
+    const { lift, state } = await loadLift();
+    state.current_mode = RomiCore.LiftState.MODE_UNKNOWN;
+    const { wrapper, liftSVGRect } = buildWrapper(lift, state);
+    expect(liftSVGRect.hasClass(/(makeStyles)-(unknownLift)-(\d+)/)).toBe(true);
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
+    wrapper.unmount();
+  });
 });
 
 describe('Checks assignation of styles on combination of motion states and mode of the Lift', () => {
@@ -100,6 +109,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(humanMode)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual('L1');
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
     wrapper.unmount();
   });
 
@@ -110,6 +120,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(liftOnCurrentFloor)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual('L1');
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
     wrapper.unmount();
   });
 
@@ -121,6 +132,7 @@ describe('Checks assignation of styles on combination of motion states and mode 
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(liftMoving)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual('L3 → L4');
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
     wrapper.unmount();
   });
 
@@ -132,6 +144,32 @@ describe('Checks assignation of styles on combination of motion states and mode 
     const { wrapper, liftSVGRect } = buildWrapper(lift, state);
     expect(liftSVGRect.hasClass(/(makeStyles)-(liftMoving)-(\d+)/)).toBe(true);
     expect(wrapper.find('#liftMotion').text()).toEqual(`L4 → L2`);
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  test('Lift its not on current floor and its mode is UNKNOWN', async () => {
+    const { lift, state } = await loadLift();
+    state.current_floor = 'L4';
+    state.destination_floor = 'L2';
+    state.current_mode = RomiCore.LiftState.MODE_HUMAN;
+    state.motion_state = RomiCore.LiftState.MOTION_DOWN;
+    const { wrapper, liftSVGRect } = buildWrapper(lift, state);
+    expect(liftSVGRect.hasClass(/(makeStyles)-(liftMoving)-(\d+)/)).toBe(true);
+    expect(wrapper.find('#liftMotion').text()).toEqual(`L4 → L2`);
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  test('Lift its on current floor and its mode is UNKNOWN', async () => {
+    const { lift, state } = await loadLift();
+    state.current_floor = 'L1';
+    state.current_mode = RomiCore.LiftState.MODE_UNKNOWN;
+    state.motion_state = RomiCore.LiftState.MOTION_STOPPED;
+    const { wrapper, liftSVGRect } = buildWrapper(lift, state);
+    expect(liftSVGRect.hasClass(/(makeStyles)-(unknownLift)-(\d+)/)).toBe(true);
+    expect(wrapper.find('#liftMotion').text()).toEqual(`L1`);
+    expect(wrapper.find('#liftMode').exists()).toBe(false);
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
Fixes #30 

## What's new
* We now use dark grey when the lift is not initialized.
* If the mode of the lift is `UNKNOWN` and if the lift has defined states, the current_level will be shown instead of the `UNKNOWN` label.
* When the lift is stationary at a level, the printout is the current_level name but if the lift is moving, it prints the destination text (L1->L3) at the same location.
* Switched places of the LiftMotion text and LiftMode text