### PR TITLE
fix: use env vars to specify soss and trajectory server urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,7 @@ cd romi-dashboard
 npm install
 ```
 
-## Launching dev server
-
-The following environment variables need to be defined
-
-  * REACT_APP_SOSS_SERVER
-  * REACT_APP_SOSS_TOKEN
-  * REACT_APP_TRAJECTORY_SERVER
+## Launching
 
 Launch the web application using the commands below,
 
@@ -36,13 +30,17 @@ cd ~/romi-dashboard
 npm start
 ```
 
-or alternatively, if using the soss config from e2e-tests, you can launch it with
+or alternatively, if using a different soss or trajectory server, the follow env variables can be defined
+
+  * REACT_APP_SOSS_SERVER
+  * REACT_APP_SOSS_TOKEN
+  * REACT_APP_TRAJECTORY_SERVER
+
+and launched with
 
 ```bash
-npm run start:test
+npm run start:custom
 ```
-
-This will define the environment variables as required for the soss and trajectory servers.
 
 At this point, the dashboard should have been launched on the default browser of the machine, under `localhost:3000`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ROMI-dashboard
+## RoMi-dashboard
 
 Hello! `romi-dashboard` is a web application that provides overall visualization and control over the RoMi-H system.
 
@@ -21,7 +21,13 @@ cd romi-dashboard
 npm install
 ```
 
-## Launch
+## Launching dev server
+
+The following environment variables need to be defined
+
+  * REACT_APP_SOSS_SERVER
+  * REACT_APP_SOSS_TOKEN
+  * REACT_APP_TRAJECTORY_SERVER
 
 Launch the web application using the commands below,
 
@@ -30,6 +36,31 @@ cd ~/romi-dashboard
 npm start
 ```
 
-At this point, the dashboard should have been launched on the default browser of the machine, under `localhost:3000`. 
+or alternatively, if using the soss config from e2e-tests, you can launch it with
+
+```bash
+npm run start:test
+```
+
+This will define the environment variables as required for the soss and trajectory servers.
+
+At this point, the dashboard should have been launched on the default browser of the machine, under `localhost:3000`.
 
 For development, the page will reload if edits are made, while any lint errors will also appear on the console.
+
+## Building for production
+
+**Note: Not fully supported yet as it is missing a way to obtain the soss token.**
+
+The following environment variables need to be defined
+
+  * REACT_APP_SOSS_SERVER
+  * REACT_APP_TRAJECTORY_SERVER
+
+build using the command
+
+```bash
+npm run build
+```
+
+You can then serve the `build` directory using the webserver of your choice.

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "uuid": "^8.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "REACT_APP_SOSS_SERVER=wss://localhost:50001 REACT_APP_SOSS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoicm9taS1kYXNoYm9hcmQiLCJpYXQiOjE1ODMyODYyMTV9.x9aNjcLujQPHchWEsbrRbvctmnGQtEzw-81X0aPIE-Y REACT_APP_TRAJECTORY_SERVER=ws://localhost:8006 react-scripts start",
     "start:mock": "REACT_APP_MOCK=1 react-scripts start",
-    "start:test": "REACT_APP_SOSS_SERVER=wss://localhost:50001 REACT_APP_SOSS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoicm9taS1kYXNoYm9hcmQiLCJpYXQiOjE1ODMyODYyMTV9.x9aNjcLujQPHchWEsbrRbvctmnGQtEzw-81X0aPIE-Y REACT_APP_TRAJECTORY_SERVER=ws://localhost:8006 react-scripts start",
+    "start:custom": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --testPathIgnorePatterns integration-tests",
     "test:integration": "node src/integration-tests/launch.js test --testPathPattern integration-tests",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "start": "react-scripts start",
     "start:mock": "REACT_APP_MOCK=1 react-scripts start",
+    "start:test": "REACT_APP_SOSS_SERVER=wss://localhost:50001 REACT_APP_SOSS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoicm9taS1kYXNoYm9hcmQiLCJpYXQiOjE1ODMyODYyMTV9.x9aNjcLujQPHchWEsbrRbvctmnGQtEzw-81X0aPIE-Y REACT_APP_TRAJECTORY_SERVER=ws://localhost:8006 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --testPathIgnorePatterns integration-tests",
     "test:integration": "node src/integration-tests/launch.js test --testPathPattern integration-tests",

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -12,13 +12,24 @@ export interface AppConfig {
 export let appConfig: AppConfig;
 
 if (!process.env.REACT_APP_MOCK && process.env.NODE_ENV !== 'test') {
-  // { user: 'romi-dashboard' } signed with HS256 + secret 'rmf'
-  // prettier-ignore
-  const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoicm9taS1kYXNoYm9hcmQiLCJpYXQiOjE1ODMyODYyMTV9.x9aNjcLujQPHchWEsbrRbvctmnGQtEzw-81X0aPIE-Y'
+  const sossNodeName = process.env.REACT_APP_SOSS_NODE_NAME || 'romi-dashboard';
+
+  const sossServer = process.env.REACT_APP_SOSS_SERVER;
+  if (!sossServer) {
+    throw new Error('REACT_APP_SOSS_SERVER env variable is needed but not defined');
+  }
+
+  // TODO: get token from some auth service
+  const token = process.env.REACT_APP_SOSS_TOKEN || '';
+
+  const trajServer = process.env.REACT_APP_TRAJECTORY_SERVER;
+  if (!trajServer) {
+    throw new Error('REACT_APP_TRAJECTORY_SERVER env variable is needed but not defined');
+  }
 
   appConfig = {
-    transportFactory: () => SossTransport.connect('romi-dashboard', 'wss://localhost:50001', token),
-    trajectoryManagerFactory: () => DefaultTrajectoryManager.create('ws://localhost:8006'),
+    transportFactory: () => SossTransport.connect(sossNodeName, sossServer, token),
+    trajectoryManagerFactory: () => DefaultTrajectoryManager.create(trajServer),
   };
 } else {
   appConfig = {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -2,5 +2,10 @@
 declare namespace NodeJS {
   interface ProcessEnv {
     readonly REACT_APP_MOCK: boolean;
+    readonly REACT_APP_SOSS_NODE_NAME?: string;
+    readonly REACT_APP_SOSS_SERVER: string;
+    // TODO: remove this, use an auth service to get the token instead
+    readonly REACT_APP_SOSS_TOKEN: string;
+    readonly REACT_APP_TRAJECTORY_SERVER: string;
   }
 }


### PR DESCRIPTION
fixes #33 