### PR TITLE
Fix/outline trajectory animation sometimes clips#41

### DIFF
--- a/src/components/schedule-visualizer/trajectory-animations.tsx
+++ b/src/components/schedule-visualizer/trajectory-animations.tsx
@@ -188,9 +188,6 @@ export function withOutlineAnimation(
 
     return (
       <g>
-        {/* <mask id={`${trajectory.id}-mask`} width={'120px'} height={'80%'}>
-          <rect x={0} y={0} width={'120%'} height={'120%'} fill={'white'} />
-        </mask> */}
         <TrajectoryComponent ref={pathRef} {...props} mask={`url(#${trajectory.id}-mask)`} />
       </g>
     );

--- a/src/components/schedule-visualizer/trajectory-animations.tsx
+++ b/src/components/schedule-visualizer/trajectory-animations.tsx
@@ -145,6 +145,7 @@ export function withOutlineAnimation(
 
       const mask = document.createElementNS('http://www.w3.org/2000/svg', 'mask');
       mask.setAttribute('id', `${trajectory.id}-mask`);
+      mask.setAttribute('width', '100');
       const maskRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
       maskRect.setAttribute('x', '0');
       maskRect.setAttribute('y', '0');
@@ -187,6 +188,9 @@ export function withOutlineAnimation(
 
     return (
       <g>
+        {/* <mask id={`${trajectory.id}-mask`} width={'120px'} height={'80%'}>
+          <rect x={0} y={0} width={'120%'} height={'120%'} fill={'white'} />
+        </mask> */}
         <TrajectoryComponent ref={pathRef} {...props} mask={`url(#${trajectory.id}-mask)`} />
       </g>
     );


### PR DESCRIPTION
Fixes #41 
## What's new
Fixed the outline trajectory both in Chrome and Firefox

The problem was that the trajectory mask did not cover the entire trajectory space. I solved the problem by giving more space to the mask.

![image](https://user-images.githubusercontent.com/11761240/86624635-a0f81f00-bf91-11ea-8a07-72377793c971.png)
