### PR TITLE
fix unknown target fleet form errors

### DIFF
--- a/src/components/loop-form.tsx
+++ b/src/components/loop-form.tsx
@@ -28,7 +28,9 @@ export const LoopForm = (props: LoopFormProps) => {
   );
 
   useEffect(() => {
-    setListOfPlaces(fakePlaces()[targetFleetName]);
+    fakePlaces()[targetFleetName]
+      ? setListOfPlaces(fakePlaces()[targetFleetName])
+      : setListOfPlaces([]);
   }, [targetFleetName]);
 
   useEffect(() => {


### PR DESCRIPTION
![LoopFormError](https://user-images.githubusercontent.com/29136440/90368373-817a0900-e09c-11ea-8d5f-fefd45310cbe.png)

On the commands panel, selecting an empty fleet (when you click the cancel option inside the autocomplete for target fleet) will result in the error thrown above, crashing the app. This is because the value of the fleet is not in the places object, hence `setListOfPlaces` would set the `listOfPlaces` value as `undefined. 

I added a simple check to make sure that the value of the fleet is in the places object, otherwise, the value would be set to an empty array.