### PR TITLE
fix: robot double click regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18280,7 +18280,7 @@
     },
     "react": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "resolved": false,
       "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "requires": {
         "loose-envify": "^1.1.0",
@@ -18665,7 +18665,7 @@
     },
     "react-dom": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "resolved": false,
       "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "requires": {
         "loose-envify": "^1.1.0",

--- a/src/components/schedule-visualizer/robot-default-icon.tsx
+++ b/src/components/schedule-visualizer/robot-default-icon.tsx
@@ -16,7 +16,7 @@ const RobotDefaultIcon = React.forwardRef(function(
   ref: React.Ref<SVGGElement>,
 ): React.ReactElement {
   const classes = useStyles();
-  const { robot, footprint, colorManager, inConflict, onClick } = props;
+  const { robot, footprint, colorManager, inConflict } = props;
   const [robotColor, setRobotColor] = useState<string | null>(() =>
     colorManager.robotColorFromCache(robot.name, robot.model),
   );
@@ -47,7 +47,6 @@ const RobotDefaultIcon = React.forwardRef(function(
           </filter>
           <circle
             className={classes.robotMarker}
-            onClick={e => onClick && onClick(e, robot)}
             r={footprint}
             fill={robotColor}
             filter={`url(#${robot.name}-shadow)`}

--- a/src/components/schedule-visualizer/robot-image-icon.tsx
+++ b/src/components/schedule-visualizer/robot-image-icon.tsx
@@ -27,7 +27,7 @@ const RobotImageIcon = React.forwardRef(function(
   ref: React.Ref<SVGGElement>,
 ): React.ReactElement {
   const classes = useStyles();
-  const { robot, footprint, iconPath, dispatchIconError, onClick, inConflict } = props;
+  const { robot, footprint, iconPath, dispatchIconError, inConflict } = props;
   const theme = useTheme();
   // The default icon uses footprint as the radius, so we * 2 here because the width/height
   // is in a square. With the double size of the footprint, we achieved a similar
@@ -46,9 +46,8 @@ const RobotImageIcon = React.forwardRef(function(
       {!!iconPath && (
         <g
           className={classes.robotImgContainer}
-          transform={`translate(${topVerticeX} ${-topVerticeY}) 
+          transform={`translate(${topVerticeX} ${-topVerticeY})
             rotate(${-(robot.location.yaw * 180) / Math.PI}, ${footprint}, ${footprint})`}
-          onClick={e => onClick && onClick(e, robot)}
         >
           <filter id={`${robot.name}-shadow`} x="-20%" y="-20%" width="140%" height="140%">
             <feDropShadow

--- a/src/components/schedule-visualizer/robot.tsx
+++ b/src/components/schedule-visualizer/robot.tsx
@@ -56,14 +56,12 @@ const Robot = React.forwardRef(function(
             footprint={footprint}
             dispatchIconError={setRenderCustomIcon}
             inConflict={inConflict}
-            onClick={onClick}
           />
         ) : (
           <RobotDefaultIcon
             robot={robot}
             footprint={footprint}
             colorManager={colorManager}
-            onClick={onClick}
             inConflict={inConflict}
           ></RobotDefaultIcon>
         )}


### PR DESCRIPTION
In storybook, clicking on the robot icons triggers 2 onclick callback.

This was previously fixed but seems to have came back.