### PR TITLE
fix: robot icon subelements selectable

### DIFF
--- a/src/components/schedule-visualizer/robot-default-icon.tsx
+++ b/src/components/schedule-visualizer/robot-default-icon.tsx
@@ -1,13 +1,6 @@
-import { makeStyles, useTheme } from '@material-ui/core';
+import { useTheme } from '@material-ui/core';
 import React, { useState } from 'react';
 import { RobotProps } from './robot';
-
-const useStyles = makeStyles(() => ({
-  robotMarker: {
-    cursor: 'pointer',
-    pointerEvents: 'auto',
-  },
-}));
 
 type RobotDefaultIconProps = Omit<RobotProps, 'fleetName'>;
 
@@ -15,7 +8,6 @@ const RobotDefaultIcon = React.forwardRef(function(
   props: RobotDefaultIconProps,
   ref: React.Ref<SVGGElement>,
 ): React.ReactElement {
-  const classes = useStyles();
   const { robot, footprint, colorManager, inConflict } = props;
   const [robotColor, setRobotColor] = useState<string | null>(() =>
     colorManager.robotColorFromCache(robot.name, robot.model),
@@ -45,12 +37,7 @@ const RobotDefaultIcon = React.forwardRef(function(
               floodColor={inConflict ? theme.palette.error.main : theme.palette.common.black}
             />
           </filter>
-          <circle
-            className={classes.robotMarker}
-            r={footprint}
-            fill={robotColor}
-            filter={`url(#${robot.name}-shadow)`}
-          />
+          <circle r={footprint} fill={robotColor} filter={`url(#${robot.name}-shadow)`} />
           <line x2={footprint} stroke={theme.palette.common.black} strokeWidth="0.05" />
         </g>
       )}

--- a/src/components/schedule-visualizer/robot-image-icon.tsx
+++ b/src/components/schedule-visualizer/robot-image-icon.tsx
@@ -1,16 +1,7 @@
-import { makeStyles, useTheme } from '@material-ui/core';
+import { useTheme } from '@material-ui/core';
 import React, { useMemo } from 'react';
 import { transformMiddleCoordsOfRectToSVGBeginPoint } from '../../util/calculation-helpers';
 import { RobotProps } from './robot';
-
-const useStyles = makeStyles(() => ({
-  robotImg: {
-    transformOrigin: 'center',
-  },
-  robotImgContainer: {
-    pointerEvents: 'visible',
-  },
-}));
 
 type RobotImageIconProps = Omit<RobotProps, 'colorManager' | 'fleetName'> & {
   iconPath: string;
@@ -26,7 +17,6 @@ const RobotImageIcon = React.forwardRef(function(
   props: RobotImageIconProps,
   ref: React.Ref<SVGGElement>,
 ): React.ReactElement {
-  const classes = useStyles();
   const { robot, footprint, iconPath, dispatchIconError, inConflict } = props;
   const theme = useTheme();
   // The default icon uses footprint as the radius, so we * 2 here because the width/height
@@ -45,7 +35,6 @@ const RobotImageIcon = React.forwardRef(function(
     <>
       {!!iconPath && (
         <g
-          className={classes.robotImgContainer}
           transform={`translate(${topVerticeX} ${-topVerticeY})
             rotate(${-(robot.location.yaw * 180) / Math.PI}, ${footprint}, ${footprint})`}
         >

--- a/src/components/schedule-visualizer/robot.tsx
+++ b/src/components/schedule-visualizer/robot.tsx
@@ -16,6 +16,12 @@ const useStyles = makeStyles(() => ({
     fill: 'white',
     /* 1 pixel black shadow to left, top, right and bottom */
     textShadow: '-1px 0 black, 0 1px black, 1px 0 black, 0 -1px black',
+    pointerEvents: 'none',
+  },
+
+  container: {
+    pointerEvents: 'visible',
+    cursor: 'pointer',
   },
 }));
 
@@ -46,6 +52,7 @@ const Robot = React.forwardRef(function(
       <g
         ref={ref}
         data-component="Robot"
+        className={classes.container}
         aria-label={robot.name}
         onClick={e => onClick && onClick(e, robot)}
       >


### PR DESCRIPTION
This is built on top of #92.

For some reason the subelements of a robot icon like text, direction line etc are select-able in storybook, but it's not select-able in the dashboard. This do some refactoring to handle all events in the generic "robot icon" container so the storybook icons works the same way as the dashboard.