### PR TITLE
fix: missing shadows for robot names with spaces

### DIFF
--- a/src/components/schedule-visualizer/robot-default-icon.tsx
+++ b/src/components/schedule-visualizer/robot-default-icon.tsx
@@ -34,7 +34,11 @@ const RobotDefaultIcon = React.forwardRef(function(
               floodColor={inConflict ? theme.palette.error.main : theme.palette.common.black}
             />
           </filter>
-          <circle r={footprint} fill={robotColor} filter={`url(#${robot.name}-shadow)`} />
+          <circle
+            r={footprint}
+            fill={robotColor}
+            filter={`url(${encodeURI(`#${robot.name}-shadow`)}`}
+          />
           <line x2={footprint} stroke={theme.palette.common.black} strokeWidth="0.05" />
         </g>
       )}


### PR DESCRIPTION
This is built on top of #94.

This fixes a bug where shadows are missing when the robot name has spaces, this is caused by unescaped filter ids in the elements.