### PR TITLE
ci: run e2e natively

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,35 +1,35 @@
 name: Nightly
-on: push
-  # schedule:
-  #   # 2am SGT
-  #   - cron: '0 18 * * *'
+on:
+  schedule:
+    # 2am SGT
+    - cron: '0 18 * * *'
 jobs:
-  # build-docker-images:
-  #   name: Push Docker image to GitHub Packages
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Push rmf image to GitHub Packages
-  #       uses: docker/build-push-action@v1
-  #       with:
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #         registry: docker.pkg.github.com
-  #         repository: ${{ github.repository }}/rmf
-  #         tags: nightly
-  #         path: docker/rmf
-  #     - name: Push e2e image to GitHub Packages
-  #       uses: docker/build-push-action@v1
-  #       with:
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #         registry: docker.pkg.github.com
-  #         repository: ${{ github.repository }}/e2e
-  #         tags: latest
-  #         dockerfile: docker/e2e.Dockerfile
+  build-docker-images:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Push rmf image to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: ${{ github.repository }}/rmf
+          tags: nightly
+          path: docker/rmf
+      - name: Push e2e image to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: ${{ github.repository }}/e2e
+          tags: latest
+          dockerfile: docker/e2e.Dockerfile
   unit-test:
     name: Unit Test
-    # needs: build-docker-images
+    needs: build-docker-images
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   e2e-test:
     name: End-to-End Test
-    # needs: build-docker-images
+    needs: build-docker-images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,32 +4,32 @@ on: push
   #   # 2am SGT
   #   - cron: '0 18 * * *'
 jobs:
-  build-docker-images:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Push rmf image to GitHub Packages
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: ${{ github.repository }}/rmf
-          tags: nightly
-          path: docker/rmf
-      - name: Push e2e image to GitHub Packages
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: ${{ github.repository }}/e2e
-          tags: latest
-          dockerfile: docker/e2e.Dockerfile
+  # build-docker-images:
+  #   name: Push Docker image to GitHub Packages
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Push rmf image to GitHub Packages
+  #       uses: docker/build-push-action@v1
+  #       with:
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #         registry: docker.pkg.github.com
+  #         repository: ${{ github.repository }}/rmf
+  #         tags: nightly
+  #         path: docker/rmf
+  #     - name: Push e2e image to GitHub Packages
+  #       uses: docker/build-push-action@v1
+  #       with:
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #         registry: docker.pkg.github.com
+  #         repository: ${{ github.repository }}/e2e
+  #         tags: latest
+  #         dockerfile: docker/e2e.Dockerfile
   unit-test:
     name: Unit Test
-    needs: build-docker-images
+    # needs: build-docker-images
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   e2e-test:
     name: End-to-End Test
-    needs: build-docker-images
+    # needs: build-docker-images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,15 +1,15 @@
 name: Nightly
-on:
-  schedule:
-    # 2am SGT
-    - cron: '0 18 * * *'
+on: push
+  # schedule:
+  #   # 2am SGT
+  #   - cron: '0 18 * * *'
 jobs:
   build-docker-images:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Push to GitHub Packages
+      - name: Push rmf image to GitHub Packages
         uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}
@@ -18,6 +18,15 @@ jobs:
           repository: ${{ github.repository }}/rmf
           tags: nightly
           path: docker/rmf
+      - name: Push e2e image to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: ${{ github.repository }}/e2e
+          tags: latest
+          dockerfile: docker/e2e.Dockerfile
   unit-test:
     name: Unit Test
     needs: build-docker-images

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ password: admin
 
 ### Docker Based Backend
 
+If you have problem setting up rmf and soss, you can make use of the docker image used by the e2e tests to run the backend in docker.
+
 First, download the docker images, the images are hosted on github packages so you will need a github account to access it, refer to [here](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages) for instructions.
 
 After you have the credentials set up, run this to download the images
@@ -108,11 +110,13 @@ After you have the credentials set up, run this to download the images
 npm run sync:docker
 ```
 
-Then start the backend servers with
+Then run this to start the dev services
 
 ```bash
 npm run start:docker
 ```
+
+This will start all the services in a docker container, the react web app will be hosted at `localhost:3000`.
 
 The rmf image is built nightly, if you would like to test against the latest build, be sure to update the docker images regularly.
 
@@ -121,9 +125,12 @@ The rmf image is built nightly, if you would like to test against the latest bui
 If you would like, you can also build the images locally, doing so is simple with
 
 ```bash
+# build rmf image
 docker-compose -f <path-to-romi-dashboard>/docker/rmf/docker-compose.yml build --no-cache
-# run this to use the newly built image for the npm scripts
+# tag it as nightly
 docker tag docker.pkg.github.com/osrf/romi-dashboard/rmf:latest docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
+# build e2e image
+docker-compose -f <path-to-romi-dashboard>/docker/docker-compose.yml build --no-cache e2e
 ```
 
 This will download and build all of rmf so it may take awhile.

--- a/docker/chrome-no-sandbox
+++ b/docker/chrome-no-sandbox
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec google-chrome --no-sandbox "$@"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 services:
   trajectory-server:
     image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
@@ -6,7 +6,6 @@ services:
     ports:
       - 8006:8006
   office-demo:
-
     image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
     command: ros2 launch demos office.launch.xml headless:=true
   soss:
@@ -26,3 +25,19 @@ services:
   probe-rmf:
     image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
     command: bash -c 'while [ ! $$(ros2 node list | grep rmf_traffic) ]; do sleep 1; done;'
+  e2e:
+    build:
+      context: ..
+      dockerfile: docker/e2e.Dockerfile
+    image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ..:/root/romi-dashboard
+    working_dir: /root/romi-dashboard
+    environment:
+      CI: 1
+      CHROME_BIN: /chrome-no-sandbox
+    ipc: host
+    network_mode: host
+    privileged: true
+    command: npm run test:e2e -- --spec e2e/tests/1-login.test.ts

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,20 +1,5 @@
 version: '3'
 services:
-  trajectory-server:
-    image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
-    command: ros2 launch visualizer server.xml
-    ports:
-      - 8006:8006
-  office-demo:
-    image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
-    command: ros2 launch demos office.launch.xml headless:=true
-  soss:
-    image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
-    command: soss /root/romi-dashboard/e2e/soss.yaml
-    volumes:
-      - ../e2e:/root/romi-dashboard/e2e
-    ports:
-      - 50001:50001
   auth:
     build:
       context: .
@@ -22,9 +7,6 @@ services:
     image: romi-dashboard/auth
     ports:
       - 8080:8080
-  probe-rmf:
-    image: docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
-    command: bash -c 'while [ ! $$(ros2 node list | grep rmf_traffic) ]; do sleep 1; done;'
   e2e:
     build:
       context: ..
@@ -41,3 +23,13 @@ services:
     network_mode: host
     privileged: true
     command: npm run test:e2e -- --spec e2e/tests/1-login.test.ts
+  dev:
+    image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ..:/root/romi-dashboard
+    working_dir: /root/romi-dashboard
+    ipc: host
+    network_mode: host
+    privileged: true
+    command: bash -c 'BROWSER=none npm start'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ipc: host
     network_mode: host
     privileged: true
-    command: npm run test:e2e -- --spec e2e/tests/1-login.test.ts
+    command: npm run test:e2e
   dev:
     image: docker.pkg.github.com/osrf/romi-dashboard/e2e
     volumes:

--- a/docker/e2e.Dockerfile
+++ b/docker/e2e.Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
+
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \
+  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && apt-get install -y nodejs google-chrome-stable docker.io docker-compose \
+  && rm -rf /var/lib/apt/lists/*
+
+ADD docker/chrome-no-sandbox /

--- a/e2e/env.sh
+++ b/e2e/env.sh
@@ -4,3 +4,4 @@ export TS_NODE_PROJECT=e2e/tsconfig.json
 export REACT_APP_SOSS_SERVER=wss://localhost:50001
 export REACT_APP_TRAJECTORY_SERVER=ws://localhost:8006
 export ROMI_DASHBOARD_PORT=5000
+export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-romidashboarde2e} # underscores and hyphens doesn't seem to work for ubuntu 18.04's version of docker-compose

--- a/e2e/rmf-launcher.ts
+++ b/e2e/rmf-launcher.ts
@@ -4,7 +4,6 @@ enum LaunchMode {
   None,
   Local,
   LocalSingleton,
-  Docker,
 }
 
 interface Launcher {
@@ -17,7 +16,6 @@ interface Launcher {
  * mode is based on the ROMI_DASHBOARD_LAUNCH_MODE environment variable, the values can be one of
  *
  *   * none
- *   * docker
  *   * local
  *
  * Defaults to `local`.
@@ -28,9 +26,7 @@ interface Launcher {
  */
 export function makeLauncher(launchMode?: LaunchMode): Launcher {
   if (!launchMode) {
-    if (process.env.ROMI_DASHBOARD_LAUNCH_MODE === 'docker') {
-      launchMode = LaunchMode.Docker;
-    } else if (process.env.ROMI_DASHBOARD_LAUNCH_MODE === 'none') {
+    if (process.env.ROMI_DASHBOARD_LAUNCH_MODE === 'none') {
       launchMode = LaunchMode.None;
     } else {
       launchMode = LaunchMode.LocalSingleton;
@@ -40,8 +36,6 @@ export function makeLauncher(launchMode?: LaunchMode): Launcher {
   switch (launchMode) {
     case LaunchMode.None:
       return new StubLauncher();
-    case LaunchMode.Docker:
-      return new DockerLauncher();
     case LaunchMode.Local:
       return new LocalLauncher();
     case LaunchMode.LocalSingleton:
@@ -214,78 +208,6 @@ class ManagedProcess {
 
   private _proc: ChildProcess.ChildProcess;
   private _procAlive = false;
-}
-
-/**
- * Launches rmf components in docker containers.
- */
-export class DockerLauncher {
-  async launch(): Promise<void> {
-    ChildProcess.spawn(
-      `${__dirname}/../scripts/dockert`,
-      [
-        'docker-compose',
-        '-f',
-        `${__dirname}/../docker/docker-compose.yml`,
-        'up',
-        'office-demo',
-        'trajectory-server',
-        'soss',
-      ],
-      { stdio: 'inherit' },
-    );
-
-    const ready = await this._rmfReady();
-    if (!ready) {
-      throw new Error('unable to detect rmf');
-    }
-  }
-
-  async kill(): Promise<void> {
-    return new Promise(res => {
-      const proc = ChildProcess.spawn(`${__dirname}/../scripts/dockert`, [
-        'docker-compose',
-        '-f',
-        `${__dirname}/../docker/docker-compose.yml`,
-        'stop',
-        'office-demo',
-        'trajectory-server',
-        'soss',
-      ]);
-      proc.once('exit', res);
-    });
-  }
-
-  private async _rmfReady(timeout: number = 30000): Promise<boolean> {
-    return new Promise(res => {
-      const proc = ChildProcess.spawn(
-        `${__dirname}/../scripts/dockert`,
-        [
-          'docker-compose',
-          '-f',
-          `${__dirname}/../docker/docker-compose.yml`,
-          'up',
-          '--exit-code-from',
-          'probe-rmf',
-          'probe-rmf',
-        ],
-        { stdio: 'inherit' },
-      );
-      if (!proc) {
-        return res(false);
-      }
-
-      const timer = setTimeout(() => {
-        proc.kill();
-        res(false);
-      }, timeout);
-
-      proc.once('exit', code => {
-        clearTimeout(timer);
-        res(code === 0);
-      });
-    });
-  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -7803,16 +7803,16 @@
       }
     },
     "chromedriver": {
-      "version": "85.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-85.0.1.tgz",
-      "integrity": "sha512-z8je3U4tXFZnx7AloRabM4Ep1lpFJvHxLoGuRvLg33Qy0UKk/z6OXmHUO2z6DKE0Oe6CFpjj/bdhuQ8dfvq9ug==",
+      "version": "83.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.1.tgz",
+      "integrity": "sha512-51/YsLIMRF+L0ooMlM4aZjyoOpDs0gDXGlT6+/CwWEnvK53PUyef9FkotKbzknCaUeL/qUw3ic3IMmsNc+SUxg==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.19.2",
         "del": "^5.1.0",
-        "extract-zip": "^2.0.1",
-        "https-proxy-agent": "^5.0.0",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^2.2.4",
         "mkdirp": "^1.0.4",
         "tcp-port-used": "^1.0.1"
       },
@@ -7824,12 +7824,12 @@
           "dev": true
         },
         "agent-base": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "dev": true,
           "requires": {
-            "debug": "4"
+            "es6-promisify": "^5.0.0"
           }
         },
         "array-union": {
@@ -7845,6 +7845,15 @@
           "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
           }
         },
         "del": {
@@ -7912,13 +7921,13 @@
           }
         },
         "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4"
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
           }
         },
         "ignore": {
@@ -10156,6 +10165,21 @@
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "es6-shim": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4113,6 +4113,15 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
+    "@types/puppeteer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.2.tgz",
+      "integrity": "sha512-JRuHPSbHZBadOxxFwpyZPeRlpPTTeMbQneMdpFd8LXdyNfFSiX950CGewdm69g/ipzEAXAmMyFF1WOWJOL/nKw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -4603,16 +4612,63 @@
       }
     },
     "@wdio/local-runner": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-6.1.19.tgz",
-      "integrity": "sha512-/oKSkVTEcDh/qeF5r8pZC8TsrMDoI9scRMbomLxKHwf+ydeSolxAtaQ4l0aT0ScN7KXcNsfYpwezKOT4rd/mlQ==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-6.4.7.tgz",
+      "integrity": "sha512-aZErJJ4QT14wN0p7Z3Qe3xcrdgDnCXE/79YDFzqqdD3uQ6STD5oLsqDuLU5UhX/b5MWmFWRuBzfFvHpHjJ+uWw==",
       "dev": true,
       "requires": {
-        "@wdio/logger": "6.0.16",
-        "@wdio/repl": "6.1.17",
-        "@wdio/runner": "6.1.19",
+        "@wdio/logger": "6.4.7",
+        "@wdio/repl": "6.4.7",
+        "@wdio/runner": "6.4.7",
         "async-exit-hook": "^2.0.1",
         "stream-buffers": "^3.0.2"
+      },
+      "dependencies": {
+        "@wdio/logger": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.4.7.tgz",
+          "integrity": "sha512-Mm/rsRa/1u/l8/IrNKM2c9tkvLE90i83d3KZ0Ujh4cicYJv+lNi9whsCi+p3QNFCo64nJ6bfC+0Ho5VgD3MiKw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "loglevel": "^1.6.0",
+            "loglevel-plugin-prefix": "^0.8.4",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@wdio/repl": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.4.7.tgz",
+          "integrity": "sha512-jU8wAGPkQg6IlkSX6n7Quwc1/f8cOMv1PkRg7+twdyJtHkEmVeCFJcF/2f1LMRlfDfwUQPBS7XEOLMlZUsXWkg==",
+          "dev": true,
+          "requires": {
+            "@wdio/utils": "6.4.7"
+          }
+        },
+        "@wdio/utils": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.4.7.tgz",
+          "integrity": "sha512-zsDMhLSNReC9ZzQNuEak8sAlEbPyjI6FYLKdX/0vIZ5opgfdaPmTg4j2Y6g7PVg6heQMvP3Ecszdexnmm7UFRQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "6.4.7"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "@wdio/logger": {
@@ -4761,18 +4817,294 @@
       }
     },
     "@wdio/runner": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-6.1.19.tgz",
-      "integrity": "sha512-Rw76qsyFUedtOPZ6yP1YvkeKLh7oapgSIVycvMnNYluOoljr9KlDp+9FDmxLcYa4aN+evTlNxKkpnNr07GvkCg==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-6.4.7.tgz",
+      "integrity": "sha512-zxoHKKDkxL9zkbABA/MpoqUU0Y/36o5in7wC7tS7JWUFSKswP/mQSa3L5d3FTakt+x2//y3lBsA7qcH5WEBZtQ==",
       "dev": true,
       "requires": {
-        "@wdio/config": "6.1.14",
-        "@wdio/logger": "6.0.16",
-        "@wdio/utils": "6.1.17",
+        "@wdio/config": "6.4.7",
+        "@wdio/logger": "6.4.7",
+        "@wdio/utils": "6.4.7",
         "deepmerge": "^4.0.0",
         "gaze": "^1.1.2",
-        "webdriver": "6.1.17",
-        "webdriverio": "6.1.19"
+        "webdriver": "6.4.7",
+        "webdriverio": "6.4.7"
+      },
+      "dependencies": {
+        "@wdio/config": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.4.7.tgz",
+          "integrity": "sha512-wtcj9yKm5+SivwhsgpusBrFR7a3rpDsN/WH6ekoqlZFs7oCpJeTLwawWnoX6MJQy2no5o00lGxDDJnqjaBdiiQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "6.4.7",
+            "deepmerge": "^4.0.0",
+            "glob": "^7.1.2"
+          }
+        },
+        "@wdio/logger": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.4.7.tgz",
+          "integrity": "sha512-Mm/rsRa/1u/l8/IrNKM2c9tkvLE90i83d3KZ0Ujh4cicYJv+lNi9whsCi+p3QNFCo64nJ6bfC+0Ho5VgD3MiKw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "loglevel": "^1.6.0",
+            "loglevel-plugin-prefix": "^0.8.4",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@wdio/protocols": {
+          "version": "6.3.6",
+          "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.3.6.tgz",
+          "integrity": "sha512-cocBRkv5sYUBxXResuxskQhIkKgDgE/yAtgMGR5wXLrtG/sMpZ2HVy6LOcOeARidAaRwbav80M2ZHjTCjPn53w==",
+          "dev": true
+        },
+        "@wdio/repl": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.4.7.tgz",
+          "integrity": "sha512-jU8wAGPkQg6IlkSX6n7Quwc1/f8cOMv1PkRg7+twdyJtHkEmVeCFJcF/2f1LMRlfDfwUQPBS7XEOLMlZUsXWkg==",
+          "dev": true,
+          "requires": {
+            "@wdio/utils": "6.4.7"
+          }
+        },
+        "@wdio/utils": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.4.7.tgz",
+          "integrity": "sha512-zsDMhLSNReC9ZzQNuEak8sAlEbPyjI6FYLKdX/0vIZ5opgfdaPmTg4j2Y6g7PVg6heQMvP3Ecszdexnmm7UFRQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "6.4.7"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "archiver": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.0.tgz",
+          "integrity": "sha512-AEWhJz6Yi6hWtN1Sqy/H4sZo/lLMJ/NftXxGaDy/TnOMmmjsRaZc/Ts+U4BsPoBQkuunTN6t8hk7iU9A+HBxLw==",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "async": "^3.2.0",
+            "buffer-crc32": "^0.2.1",
+            "readable-stream": "^3.6.0",
+            "readdir-glob": "^1.0.0",
+            "tar-stream": "^2.1.2",
+            "zip-stream": "^4.0.0"
+          }
+        },
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
+        },
+        "compress-commons": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
+          "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "^0.2.13",
+            "crc32-stream": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "crc32-stream": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
+          "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
+          "dev": true,
+          "requires": {
+            "crc": "^3.4.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "devtools": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/devtools/-/devtools-6.4.7.tgz",
+          "integrity": "sha512-sYfeAi5g9Qpe6iHGvFUc95C46tEQuk5qwPiY2d4a7cTfaTrSaSNzCRvxIAuvjWbDAPyXXvuDYz4HVPhjuJvKJQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/config": "6.4.7",
+            "@wdio/logger": "6.4.7",
+            "@wdio/protocols": "6.3.6",
+            "@wdio/utils": "6.4.7",
+            "chrome-launcher": "^0.13.1",
+            "puppeteer-core": "^5.1.0",
+            "ua-parser-js": "^0.7.21",
+            "uuid": "^8.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "puppeteer-core": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.2.1.tgz",
+          "integrity": "sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "devtools-protocol": "0.0.781568",
+            "extract-zip": "^2.0.0",
+            "https-proxy-agent": "^4.0.0",
+            "mime": "^2.0.3",
+            "pkg-dir": "^4.2.0",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^3.0.2",
+            "tar-fs": "^2.0.0",
+            "unbzip2-stream": "^1.3.3",
+            "ws": "^7.2.3"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "webdriver": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.4.7.tgz",
+          "integrity": "sha512-iNYOPjxBP+bnS9gKS3BaFu8jn2KDqxdyneZ/Q2EyxuFezJO3z9V5Q6OIVZ16z/H/Ebf6ao1LQ6e/ff7wDtO3Pw==",
+          "dev": true,
+          "requires": {
+            "@wdio/config": "6.4.7",
+            "@wdio/logger": "6.4.7",
+            "@wdio/protocols": "6.3.6",
+            "@wdio/utils": "6.4.7",
+            "got": "^11.0.2",
+            "lodash.merge": "^4.6.1"
+          }
+        },
+        "webdriverio": {
+          "version": "6.4.7",
+          "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.4.7.tgz",
+          "integrity": "sha512-+wwmmiVFPb4PEh9bGfBIdK4zKcT3NYPhQ9LfddnUIit5Qah0CjL3iY+UCY28IVp5nzZd9XPZNr71W4bErbcDQg==",
+          "dev": true,
+          "requires": {
+            "@types/puppeteer": "^3.0.1",
+            "@wdio/config": "6.4.7",
+            "@wdio/logger": "6.4.7",
+            "@wdio/repl": "6.4.7",
+            "@wdio/utils": "6.4.7",
+            "archiver": "^5.0.0",
+            "atob": "^2.1.2",
+            "css-value": "^0.0.1",
+            "devtools": "6.4.7",
+            "get-port": "^5.1.1",
+            "grapheme-splitter": "^1.0.2",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.isobject": "^3.0.2",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.zip": "^4.2.0",
+            "minimatch": "^3.0.4",
+            "puppeteer-core": "^5.1.0",
+            "resq": "^1.6.0",
+            "rgb2hex": "^0.2.0",
+            "serialize-error": "^7.0.0",
+            "webdriver": "6.4.7"
+          }
+        },
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "dev": true
+        },
+        "zip-stream": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
+          "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "compress-commons": "^4.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        }
       }
     },
     "@wdio/spec-reporter": {
@@ -7471,15 +7803,16 @@
       }
     },
     "chromedriver": {
-      "version": "83.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.0.tgz",
-      "integrity": "sha512-AePp9ykma+z4aKPRqlbzvVlc22VsQ6+rgF+0aL3B5onHOncK18dWSkLrSSJMczP/mXILN9ohGsvpuTwoRSj6OQ==",
+      "version": "85.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-85.0.1.tgz",
+      "integrity": "sha512-z8je3U4tXFZnx7AloRabM4Ep1lpFJvHxLoGuRvLg33Qy0UKk/z6OXmHUO2z6DKE0Oe6CFpjj/bdhuQ8dfvq9ug==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.19.2",
         "del": "^5.1.0",
-        "extract-zip": "^2.0.0",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
         "mkdirp": "^1.0.4",
         "tcp-port-used": "^1.0.1"
       },
@@ -7489,6 +7822,15 @@
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
           "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
           "dev": true
+        },
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
         },
         "array-union": {
           "version": "2.1.0",
@@ -7567,6 +7909,16 @@
             "ignore": "^5.1.1",
             "merge2": "^1.2.3",
             "slash": "^3.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "ignore": {
@@ -9192,6 +9544,12 @@
         "ua-parser-js": "^0.7.21",
         "uuid": "^8.0.0"
       }
+    },
+    "devtools-protocol": {
+      "version": "0.0.781568",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
+      "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==",
+      "dev": true
     },
     "diff": {
       "version": "4.0.2",
@@ -11518,6 +11876,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -19182,6 +19546,15 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdir-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.0.0.tgz",
+      "integrity": "sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "readdirp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2448,7 +2448,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -3341,7 +3345,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -6931,6 +6939,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.2",
@@ -11378,6 +11395,12 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filelist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
@@ -13829,6 +13852,8 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -16510,6 +16535,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -18819,7 +18850,7 @@
     },
     "react": {
       "version": "16.13.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "requires": {
         "loose-envify": "^1.1.0",
@@ -19204,7 +19235,7 @@
     },
     "react-dom": {
       "version": "16.13.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "requires": {
         "loose-envify": "^1.1.0",
@@ -22630,6 +22661,8 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -23504,6 +23537,8 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "start": ". e2e/env.sh && concurrently npm:start:auth npm:start:rmf npm:start:react",
     "start:docker": "ROMI_DASHBOARD_LAUNCH_MODE=docker npm run start --",
-    "start:auth": "scripts/dockert docker-compose -f docker/docker-compose.yml up auth",
+    "start:auth": ". e2e/env.sh && scripts/dockert docker-compose -f docker/docker-compose.yml up auth",
     "start:react": "react-scripts start",
     "start:react:e2e": "serve -c ../e2e/serve.json build",
     "start:mock": "REACT_APP_MOCK=1 react-scripts start",
@@ -57,7 +57,7 @@
     "test": "react-scripts test",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "test:e2e": ". e2e/env.sh && node scripts/test-e2e.js",
-    "test:e2e:docker": "ROMI_DASHBOARD_LAUNCH_MODE=docker npm run test:e2e --",
+    "test:e2e:docker": ". e2e/env.sh && scripts/dockert docker-compose -f docker/docker-compose.yml up e2e",
     "test:e2e:wdio": "ts-node -P e2e/tsconfig.json e2e/auth-ready.ts && wdio",
     "test:e2e:dev": ". e2e/env.sh && ROMI_DASHBOARD_PORT=3000 ROMI_DASHBOARD_LAUNCH_MODE=none wdio",
     "sync:docker": "docker pull docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly && docker pull quay.io/keycloak/keycloak:11.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "start": ". e2e/env.sh && concurrently npm:start:auth npm:start:rmf npm:start:react",
-    "start:docker": "ROMI_DASHBOARD_LAUNCH_MODE=docker npm run start --",
+    "start:docker": ". e2e/env.sh && scripts/dockert docker-compose -f docker/docker-compose.yml up dev",
     "start:auth": ". e2e/env.sh && scripts/dockert docker-compose -f docker/docker-compose.yml up auth",
     "start:react": "react-scripts start",
     "start:react:e2e": "serve -c ../e2e/serve.json build",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:e2e:docker": ". e2e/env.sh && scripts/dockert docker-compose -f docker/docker-compose.yml up e2e",
     "test:e2e:wdio": "ts-node -P e2e/tsconfig.json e2e/auth-ready.ts && wdio",
     "test:e2e:dev": ". e2e/env.sh && ROMI_DASHBOARD_PORT=3000 ROMI_DASHBOARD_LAUNCH_MODE=none wdio",
-    "sync:docker": "docker pull docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly && docker pull quay.io/keycloak/keycloak:11.0.0",
+    "sync:docker": "docker pull docker.pkg.github.com/osrf/romi-dashboard/e2e && docker pull quay.io/keycloak/keycloak:11.0.0",
     "eject": "react-scripts eject",
     "deploy:demo": "REACT_APP_MOCK=1 npm run build && NODE_DEBUG=gh-pages gh-pages -d build -m \"$(git rev-parse HEAD)\"",
     "setup": "node ./scripts/setup/setup.js && node ./scripts/setup/get-icons.js",

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -61,6 +61,7 @@ exports.config = {
       acceptInsecureCerts: true,
 
       'goog:chromeOptions': {
+        binary: process.env.CHROME_BIN || undefined,
         // to run chrome headless the following flags are required
         // (see https://developers.google.com/web/updates/2017/04/headless-chrome)
         args: [...headlessArgs, '--window-size=1366,768'],


### PR DESCRIPTION
Currently, the CI is ran by launch rmf services in a docker container and wdio/chrome on the host. The creates a problem that makes it hard for the CI to depend on rmf_demos for resource pack that is mandatory for dispensers to work. It may also makes it less stable as the why the tests are ran is different from what developers would use.

This change runs the whole CI in docker "natively", an e2e image is built nightly, this repo is then mounted onto that image and the tests are ran as if all the services are on the local host, hopefully this will make it easier to import resource pack when building the CI.

Relevant: #89 