### PR TITLE
Fixed test:e2e:dev command

### DIFF
--- a/packages/dashboard/e2e/package.json
+++ b/packages/dashboard/e2e/package.json
@@ -11,7 +11,8 @@
     "start:react": "serve -c ../e2e/serve.json ../build",
     "setup": "WORLD_NAME=office node scripts/get-resources-location.js",
     "build": ". ./env.sh && cd .. && npm run build",
-    "test": ". ./env.sh && npm run setup && node scripts/test-e2e.js"
+    "test": ". ./env.sh && npm run setup && node scripts/test-e2e.js",
+    "test:dev":". ./env.sh && ROMI_DASHBOARD_PORT=3000 ROMI_DASHBOARD_LAUNCH_MODE=none wdio"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -18,7 +18,7 @@
     "test": "react-scripts test",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "test:e2e": "cd e2e && npm test",
-    "test:e2e:dev": "cd e2e && . ./env.sh && ROMI_DASHBOARD_PORT=3000 ROMI_DASHBOARD_LAUNCH_MODE=none wdio",
+    "test:e2e:dev": "cd e2e && npm run test:dev",
     "sync:docker": "docker pull docker.pkg.github.com/osrf/romi-dashboard/e2e && docker pull quay.io/keycloak/keycloak:11.0.0",
     "eject": "react-scripts eject",
     "deploy:demo": "REACT_APP_MOCK=1 npm run build && NODE_DEBUG=gh-pages gh-pages -d build -m \"$(git rev-parse HEAD)\"",


### PR DESCRIPTION
##  What's new
Fixes #135

Fixes the below error on `npm run  test:e2e:dev` execution:
 ```
sh: 1: wdio: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! romi-dashboard@0.0.1-alpha.0 test:e2e:dev: `cd e2e && . ./env.sh && ROMI_DASHBOARD_PORT=3000 ROMI_DASHBOARD_LAUNCH_MODE=none wdio`
npm ERR! spawn ENOENT
``` 