### PR TITLE
Run docker e2e test from local dev env

### DIFF
--- a/packages/dashboard/docker/docker-compose.yml
+++ b/packages/dashboard/docker/docker-compose.yml
@@ -23,6 +23,22 @@ services:
     network_mode: host
     privileged: true
     command: bash -c 'npm ci --unsafe-perm && (npm test || npm test || npm test)'
+  e2e-local:
+    build:
+      context: ..
+      dockerfile: docker/e2e.Dockerfile
+    image: docker.pkg.github.com/osrf/romi-dashboard/e2e
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../../..:/root/romi-dashboard
+    working_dir: /root/romi-dashboard/packages/dashboard
+    command: bash -c 'cd e2e/ && npm test'
+    environment:
+      CI: 1
+      CHROME_BIN: /chrome-no-sandbox
+    ipc: host
+    network_mode: host
+    privileged: true
   unit-test:
     image: docker.pkg.github.com/osrf/romi-dashboard/e2e
     volumes:

--- a/packages/dashboard/docker/e2e.Dockerfile
+++ b/packages/dashboard/docker/e2e.Dockerfile
@@ -2,6 +2,7 @@ FROM docker.pkg.github.com/osrf/romi-dashboard/rmf:nightly
 
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \
+  && apt-get update \
   && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
   && apt-get install -y nodejs google-chrome-stable docker.io docker-compose \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What's new

fixes #138

* Add a service on `docker-compose.yml` file to run e2e tests on a container locally:  
`docker-compose -f docker/docker-compose.yml up e2e-local`
* Added an apt-get update to the `e2e.dockerfile`, to install the last stable version of chrome.

## Self-checks
Does not apply.

