### PR TITLE
Check tasks (plans) on the Dashboard

### DIFF
--- a/packages/dashboard/e2e/tests/task-summary.test.ts
+++ b/packages/dashboard/e2e/tests/task-summary.test.ts
@@ -1,0 +1,36 @@
+import { makeLauncher } from '../rmf-launcher';
+import { login, openRequestForm, overwriteClick, requestLoop } from './utils';
+
+describe('Loop request for task summary', () => {
+  const launcher = makeLauncher();
+
+  before(async () => await launcher.launch());
+  after(async () => await launcher.kill());
+
+  before(() => overwriteClick());
+  before(() => browser.url('/'));
+
+  before(login);
+
+  it('renders task summary', () => {
+    browser.setTimeout({ script: 120000 });
+    openRequestForm();
+    requestLoop({
+      pointA: 'pantry',
+      pointB: 'cubicle_1',
+    });
+    const backButton = $('[name="back-button"]');
+    backButton.click();
+
+    $('[data-component=MainMenu] [data-item=Plans]').click();
+
+    browser.waitUntil(() => $('[data-component=TreeItem]').isDisplayed() === true, {
+      timeout: 60000,
+      timeoutMsg: 'expected TreeItem to be not null!',
+    });
+
+    const treeItem = $('[data-component=TreeItem]');
+    expect(treeItem).toBeVisible();
+    treeItem.click();
+  });
+});

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -43,6 +43,8 @@ import RobotsPanel from './robots-panel';
 import ScheduleVisualizer from './schedule-visualizer';
 import { SpotlightValue } from './spotlight-value';
 import { DashboardTour, DashboardTourProps } from './tour/tour';
+import { TaskSummaryPanel } from './task-summary-panel';
+import TaskManager from '../managers/task-manager';
 
 const debug = Debug('App');
 const DoorAccordion = withSpotlight(DoorAccordion_);
@@ -101,6 +103,7 @@ export enum OmniPanelViewIndex {
   Dispensers,
   Commands,
   Negotiations,
+  Tasks,
 }
 
 class ViewMapNode {
@@ -123,6 +126,8 @@ function makeViewMap(): ViewMap {
   viewMap[OmniPanelViewIndex.Dispensers] = root.addChild(OmniPanelViewIndex.Dispensers);
   viewMap[OmniPanelViewIndex.Commands] = root.addChild(OmniPanelViewIndex.Commands);
   viewMap[OmniPanelViewIndex.Negotiations] = root.addChild(OmniPanelViewIndex.Negotiations);
+  viewMap[OmniPanelViewIndex.Tasks] = root.addChild(OmniPanelViewIndex.Tasks);
+
   return viewMap;
 }
 
@@ -182,6 +187,9 @@ export default function Dashboard(_props: {}): React.ReactElement {
     fleetNames.current = newFleetNames;
   }
 
+  const taskManager = React.useMemo(() => new TaskManager(), []);
+  const [tasks, setTasks] = React.useState(taskManager.tasks());
+
   const dispenserStateManager = React.useMemo(() => new DispenserStateManager(), []);
   const [dispenserStates, setDispenserStates] = React.useState<
     Readonly<Record<string, RomiCore.DispenserState>>
@@ -238,6 +246,7 @@ export default function Dashboard(_props: {}): React.ReactElement {
         liftStateManager.startSubscription(x);
         fleetManager.startSubscription(x);
         negotiationStatusManager.startSubscription();
+        taskManager.startSubscription(x);
 
         fleetManager.on('updated', () => setFleets(fleetManager.fleets()));
         liftStateManager.on('updated', () => setLiftStates(liftStateManager.liftStates()));
@@ -248,6 +257,7 @@ export default function Dashboard(_props: {}): React.ReactElement {
         negotiationStatusManager.on('updated', () =>
           setNegotiationStatus(negotiationStatusManager.allConflicts()),
         );
+        taskManager.on('updated', () => setTasks(taskManager.tasks()));
         setTransport(x);
       })
       .catch((e: CloseEvent) => {
@@ -260,6 +270,7 @@ export default function Dashboard(_props: {}): React.ReactElement {
     dispenserStateManager,
     fleetManager,
     negotiationStatusManager,
+    taskManager,
   ]);
 
   React.useEffect(() => {
@@ -386,6 +397,10 @@ export default function Dashboard(_props: {}): React.ReactElement {
     setCurrentView(OmniPanelViewIndex.Negotiations);
   }, []);
 
+  const handleMainMenuTasksClick = React.useCallback(() => {
+    setCurrentView(OmniPanelViewIndex.Tasks);
+  }, []);
+
   const omniPanelClasses = React.useMemo(
     () => ({ backButton: classes.topLeftBorder, closeButton: classes.topRightBorder }),
     [classes.topLeftBorder, classes.topRightBorder],
@@ -493,6 +508,7 @@ export default function Dashboard(_props: {}): React.ReactElement {
                     onDispensersClick={handleMainMenuDispensersClick}
                     onCommandsClick={handleMainMenuCommandsClick}
                     onNegotiationsClick={handleMainMenuNegotiationsClick}
+                    onTasksClick={handleMainMenuTasksClick}
                   />
                 </OmniPanelView>
                 <OmniPanelView id={OmniPanelViewIndex.Doors}>
@@ -537,6 +553,9 @@ export default function Dashboard(_props: {}): React.ReactElement {
                     negotiationStatusUpdateTS={statusUpdateTS.current}
                     setNegotiationTrajStore={setNegotiationTrajStore}
                   />
+                </OmniPanelView>
+                <OmniPanelView id={OmniPanelViewIndex.Tasks}>
+                  <TaskSummaryPanel transport={transport} allTasks={tasks} />
                 </OmniPanelView>
               </OmniPanel>
             </Fade>

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -555,7 +555,7 @@ export default function Dashboard(_props: {}): React.ReactElement {
                   />
                 </OmniPanelView>
                 <OmniPanelView id={OmniPanelViewIndex.Tasks}>
-                  <TaskSummaryPanel transport={transport} allTasks={tasks} />
+                  <TaskSummaryPanel allTasks={tasks} />
                 </OmniPanelView>
               </OmniPanel>
             </Fade>

--- a/packages/dashboard/src/components/main-menu.tsx
+++ b/packages/dashboard/src/components/main-menu.tsx
@@ -11,6 +11,7 @@ export interface MainMenuProps {
   onDispensersClick?(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void;
   onCommandsClick?(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void;
   onNegotiationsClick?(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void;
+  onTasksClick?(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void;
 }
 
 export const MainMenu = React.memo((props: MainMenuProps) => {
@@ -50,6 +51,12 @@ export const MainMenu = React.memo((props: MainMenuProps) => {
       <ListItem data-item="Negotiations" button={true} onClick={props.onNegotiationsClick}>
         <Typography variant="h5">Negotiations</Typography>
       </ListItem>
+      <Divider />
+
+      <ListItem data-item="Plans" button={true} onClick={props.onTasksClick}>
+        <Typography variant="h5">Plans</Typography>
+      </ListItem>
+      <Divider />
     </List>
   );
 });

--- a/packages/dashboard/src/components/task-summary-panel-item.tsx
+++ b/packages/dashboard/src/components/task-summary-panel-item.tsx
@@ -2,9 +2,26 @@ import React from 'react';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import { Divider, makeStyles, Typography } from '@material-ui/core';
-import TaskManager from '../managers/task-manager';
 const debug = Debug('OmniPanel:TaskSummary');
 
+export const formatStatus = (status: string) => {
+  return status.split('|');
+};
+
+export const getStateLabel = (state: number): string => {
+  switch (state) {
+    case RomiCore.TaskSummary.STATE_QUEUED:
+      return 'QUEUED';
+    case RomiCore.TaskSummary.STATE_ACTIVE:
+      return 'ACTIVE';
+    case RomiCore.TaskSummary.STATE_COMPLETED:
+      return 'COMPLETED';
+    case RomiCore.TaskSummary.STATE_FAILED:
+      return 'FAILED';
+    default:
+      return 'UNKNOWN';
+  }
+};
 interface TaskSummaryPanelItemProps {
   task: RomiCore.TaskSummary;
 }
@@ -18,8 +35,8 @@ export const TaskSummaryPanelItem = React.memo(
     const { task } = props;
     const classes = useStyles();
 
-    const statusDetails = TaskManager.formatStatus(task.status);
-    const stateLabel = TaskManager.getStateLabel(task.state);
+    const statusDetails = formatStatus(task.status);
+    const stateLabel = getStateLabel(task.state);
 
     return (
       <>

--- a/packages/dashboard/src/components/task-summary-panel-item.tsx
+++ b/packages/dashboard/src/components/task-summary-panel-item.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import Debug from 'debug';
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+import { Button, Divider, IconButton, makeStyles, Typography } from '@material-ui/core';
+import TaskManager, { TaskState } from '../managers/task-manager';
+import { TreeItem } from '@material-ui/lab';
+import { colorPalette } from '../util/css-utils';
+// import PauseCircleFilledIcon from '@material-ui/icons/PauseCircleFilled';
+import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
+const debug = Debug('OmniPanel:NegotiationsPanel');
+
+interface TaskSummaryPanelItemProps {
+  task: RomiCore.TaskSummary;
+}
+
+export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
+  const { task } = props;
+  const classes = useStyles();
+
+  const statusDetails = TaskManager.formatStatus(task.status);
+  const stateLabel = TaskManager.getStateLabel(task.state);
+
+  const determineStyle = (state: TaskState): string => {
+    switch (state) {
+      case TaskState.STATE_QUEUED:
+        return classes.queued;
+      case TaskState.STATE_ACTIVE:
+        return classes.active;
+      case TaskState.STATE_COMPLETED:
+        return classes.completed;
+      case TaskState.STATE_FAILED:
+        return classes.failed;
+      default:
+        return 'UNKNOWN';
+    }
+  };
+  console.log(determineStyle(task.state));
+  return (
+    <TreeItem
+      data-component="TreeItem"
+      nodeId={task.task_id}
+      key={task.task_id}
+      classes={{
+        label: `${determineStyle(task.state)} ${classes.labelContent}`,
+        root: classes.treeChildren,
+        expanded: classes.expanded,
+      }}
+      label={
+        <Typography>
+          {statusDetails.statusLabel}
+          <IconButton
+            onClick={(e) => {
+              e.preventDefault();
+              console.log('Not implemented');
+            }}
+          >
+            <PlayCircleFilledWhiteIcon />
+          </IconButton>
+        </Typography>
+      }
+    >
+      <div className={classes.accordionDetailLine}>
+        <Typography variant="body1">TaskId: </Typography>
+        <Typography variant="body1" noWrap>
+          {task.task_id}
+        </Typography>
+      </div>
+      <Divider />
+
+      <div className={classes.accordionDetailLine}>
+        <Typography variant="body1">State:</Typography>
+        <Typography variant="body1">{stateLabel}</Typography>
+      </div>
+      <Divider />
+
+      {/* <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Status:</Typography>
+          <div>
+            {statusDetails.map((detail) => {
+              return (
+                <>
+                  <Typography variant="body1"> {detail}</Typography>
+                  <Divider />
+                </>
+              );
+            })}
+          </div>
+        </div>
+        <Divider /> */}
+
+      <div className={classes.accordionDetailLine}>
+        <Typography variant="body1">Submission Time:</Typography>
+        <Typography variant="body1">{task.submission_time.sec}</Typography>
+      </div>
+      <Divider />
+
+      <div className={classes.accordionDetailLine}>
+        <Typography variant="body1">Start time:</Typography>
+        <Typography variant="body1">{task.start_time.sec}</Typography>
+      </div>
+      <Divider />
+
+      <div className={classes.accordionDetailLine}>
+        <Typography variant="body1">End Time:</Typography>
+        <Typography variant="body1">{task.end_time.sec}</Typography>
+      </div>
+    </TreeItem>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  accordionDetailLine: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: theme.spacing(0.5),
+  },
+  treeChildren: {
+    margin: '0.5rem 0',
+  },
+  labelContent: {
+    padding: '0.5rem',
+    borderRadius: '0.5rem',
+    boxShadow: '0 0 25px 0 rgb(72, 94, 116, 0.3)',
+  },
+  expanded: {
+    borderLeft: `0.1rem solid ${colorPalette.unknown}`,
+  },
+  completed: {
+    backgroundColor: 'lightgreen',
+  },
+  queued: {
+    backgroundColor: theme.palette.warning.main,
+  },
+  active: {
+    backgroundColor: 'yellow',
+  },
+  failed: {
+    backgroundColor: theme.palette.error.main,
+  },
+}));
+
+// const listItems = allTasks.map((task) => {
+//   console.log(task);
+//   const statusDetails = TaskManager.formatStatus(task.status);
+//   const stateLabel = TaskManager.getStateLabel(task.state);
+//   return (
+//     <div key={task.task_id}>
+//       <div className={classes.accordionDetailLine}>
+//         <Typography variant="body1">TaskId: </Typography>
+//         <Typography variant="body1" noWrap>
+//           {task.task_id}
+//         </Typography>
+//       </div>
+//       <Divider />
+
+//       <div className={classes.accordionDetailLine}>
+//         <Typography variant="body1">State:</Typography>
+//         <Typography variant="body1">{stateLabel}</Typography>
+//       </div>
+//       <Divider />
+
+//       <div className={classes.accordionDetailLine}>
+//         <Typography variant="body1">Status:</Typography>
+//         <div>
+//           {statusDetails.map((detail) => {
+//             return (
+//               <>
+//                 <Typography variant="body1"> {detail}</Typography>
+//                 <Divider />
+//               </>
+//             );
+//           })}
+//         </div>
+//       </div>
+//       <Divider />
+
+//       <div className={classes.accordionDetailLine}>
+//         <Typography variant="body1">Submission Time:</Typography>
+//         <Typography variant="body1">{task.submission_time.sec}</Typography>
+//       </div>
+//       <Divider />
+
+//       <div className={classes.accordionDetailLine}>
+//         <Typography variant="body1">Start time:</Typography>
+//         <Typography variant="body1">{task.start_time.sec}</Typography>
+//       </div>
+//       <Divider />
+
+//       <div className={classes.accordionDetailLine}>
+//         <Typography variant="body1">End Time:</Typography>
+//         <Typography variant="body1">{task.end_time.sec}</Typography>
+//       </div>
+//       <div className={classes.buttonWrapper}>
+//         <Button className={classes.button} variant="contained" color="primary">
+//           {'Pause'}
+//         </Button>
+//       </div>
+//     </div>
+//   );
+// });

--- a/packages/dashboard/src/components/task-summary-panel-item.tsx
+++ b/packages/dashboard/src/components/task-summary-panel-item.tsx
@@ -1,72 +1,24 @@
 import React from 'react';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
-import { Divider, IconButton, makeStyles, Typography } from '@material-ui/core';
+import { Divider, makeStyles, Typography } from '@material-ui/core';
 import TaskManager from '../managers/task-manager';
-import { TreeItem } from '@material-ui/lab';
-import { colorPalette } from '../util/css-utils';
-import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
-const debug = Debug('OmniPanel:NegotiationsPanel');
+const debug = Debug('OmniPanel:TaskSummary');
 
 interface TaskSummaryPanelItemProps {
   task: RomiCore.TaskSummary;
 }
 
 export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
+  debug('render');
   const { task } = props;
   const classes = useStyles();
 
   const statusDetails = TaskManager.formatStatus(task.status);
-  const actor = TaskManager.getActorFromStatus(task.status);
   const stateLabel = TaskManager.getStateLabel(task.state);
 
-  const determineStyle = (state: number): string => {
-    switch (state) {
-      case RomiCore.TaskSummary.STATE_QUEUED:
-        return classes.queued;
-      case RomiCore.TaskSummary.STATE_ACTIVE:
-        return classes.active;
-      case RomiCore.TaskSummary.STATE_COMPLETED:
-        return classes.completed;
-      case RomiCore.TaskSummary.STATE_FAILED:
-        return classes.failed;
-      default:
-        return 'UNKNOWN';
-    }
-  };
-
   return (
-    <TreeItem
-      data-component="TreeItem"
-      nodeId={task.task_id}
-      key={task.task_id}
-      classes={{
-        label: `${determineStyle(task.state)} ${classes.labelContent}`,
-        root: classes.treeChildren,
-        expanded: classes.expanded,
-      }}
-      label={
-        <>
-          <Typography variant="body1" noWrap>
-            <IconButton
-              // TODO: replace onClick with the pause plans logic.
-              onClick={(e) => {
-                e.preventDefault();
-                console.log('Not implemented');
-              }}
-            >
-              <PlayCircleFilledWhiteIcon />
-            </IconButton>
-            {task.task_id}
-          </Typography>
-          {actor && (
-            <Typography variant="body1" className={classes.taskActor}>
-              {actor}
-            </Typography>
-          )}
-        </>
-      }
-    >
+    <>
       <div className={classes.accordionDetailLine}>
         <Typography variant="body1">TaskId: </Typography>
         <Typography variant="body1" noWrap>
@@ -84,7 +36,7 @@ export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
       <div className={classes.accordionDetailLine}>
         <Typography variant="body1">Status:</Typography>
         <div>
-          {statusDetails.map((detail) => {
+          {statusDetails.map((detail: string) => {
             return (
               <Typography variant="body1" key={detail}>
                 {' '}
@@ -112,7 +64,7 @@ export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
         <Typography variant="body1">End Time:</Typography>
         <Typography variant="body1">{task.end_time.sec}</Typography>
       </div>
-    </TreeItem>
+    </>
   );
 };
 
@@ -121,34 +73,5 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'space-between',
     padding: theme.spacing(0.5),
-  },
-  treeChildren: {
-    margin: '0.5rem 0',
-  },
-  labelContent: {
-    padding: '0.5rem',
-    borderRadius: '0.5rem',
-    boxShadow: '0 0 25px 0 rgb(72, 94, 116, 0.3)',
-    overflowX: 'hidden',
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  expanded: {
-    borderLeft: `0.1rem solid ${colorPalette.unknown}`,
-  },
-  completed: {
-    backgroundColor: theme.palette.success.dark,
-  },
-  queued: {
-    backgroundColor: theme.palette.warning.main,
-  },
-  active: {
-    backgroundColor: theme.palette.success.light,
-  },
-  failed: {
-    backgroundColor: theme.palette.error.main,
-  },
-  taskActor: {
-    alignSelf: 'center',
   },
 }));

--- a/packages/dashboard/src/components/task-summary-panel-item.tsx
+++ b/packages/dashboard/src/components/task-summary-panel-item.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
-import { Button, Divider, IconButton, makeStyles, Typography } from '@material-ui/core';
-import TaskManager, { TaskState } from '../managers/task-manager';
+import { Divider, IconButton, makeStyles, Typography } from '@material-ui/core';
+import TaskManager from '../managers/task-manager';
 import { TreeItem } from '@material-ui/lab';
 import { colorPalette } from '../util/css-utils';
-// import PauseCircleFilledIcon from '@material-ui/icons/PauseCircleFilled';
 import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
 const debug = Debug('OmniPanel:NegotiationsPanel');
 
@@ -18,23 +17,24 @@ export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
   const classes = useStyles();
 
   const statusDetails = TaskManager.formatStatus(task.status);
+  const actor = TaskManager.getActorFromStatus(task.status);
   const stateLabel = TaskManager.getStateLabel(task.state);
 
-  const determineStyle = (state: TaskState): string => {
+  const determineStyle = (state: number): string => {
     switch (state) {
-      case TaskState.STATE_QUEUED:
+      case RomiCore.TaskSummary.STATE_QUEUED:
         return classes.queued;
-      case TaskState.STATE_ACTIVE:
+      case RomiCore.TaskSummary.STATE_ACTIVE:
         return classes.active;
-      case TaskState.STATE_COMPLETED:
+      case RomiCore.TaskSummary.STATE_COMPLETED:
         return classes.completed;
-      case TaskState.STATE_FAILED:
+      case RomiCore.TaskSummary.STATE_FAILED:
         return classes.failed;
       default:
         return 'UNKNOWN';
     }
   };
-  console.log(determineStyle(task.state));
+
   return (
     <TreeItem
       data-component="TreeItem"
@@ -46,17 +46,25 @@ export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
         expanded: classes.expanded,
       }}
       label={
-        <Typography>
-          {statusDetails.statusLabel}
-          <IconButton
-            onClick={(e) => {
-              e.preventDefault();
-              console.log('Not implemented');
-            }}
-          >
-            <PlayCircleFilledWhiteIcon />
-          </IconButton>
-        </Typography>
+        <>
+          <Typography variant="body1" noWrap>
+            <IconButton
+              // TODO: replace onClick with the pause plans logic.
+              onClick={(e) => {
+                e.preventDefault();
+                console.log('Not implemented');
+              }}
+            >
+              <PlayCircleFilledWhiteIcon />
+            </IconButton>
+            {task.task_id}
+          </Typography>
+          {actor && (
+            <Typography variant="body1" className={classes.taskActor}>
+              {actor}
+            </Typography>
+          )}
+        </>
       }
     >
       <div className={classes.accordionDetailLine}>
@@ -73,20 +81,20 @@ export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
       </div>
       <Divider />
 
-      {/* <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">Status:</Typography>
-          <div>
-            {statusDetails.map((detail) => {
-              return (
-                <>
-                  <Typography variant="body1"> {detail}</Typography>
-                  <Divider />
-                </>
-              );
-            })}
-          </div>
+      <div className={classes.accordionDetailLine}>
+        <Typography variant="body1">Status:</Typography>
+        <div>
+          {statusDetails.map((detail) => {
+            return (
+              <Typography variant="body1" key={detail}>
+                {' '}
+                {detail}
+              </Typography>
+            );
+          })}
         </div>
-        <Divider /> */}
+      </div>
+      <Divider />
 
       <div className={classes.accordionDetailLine}>
         <Typography variant="body1">Submission Time:</Typography>
@@ -121,80 +129,26 @@ const useStyles = makeStyles((theme) => ({
     padding: '0.5rem',
     borderRadius: '0.5rem',
     boxShadow: '0 0 25px 0 rgb(72, 94, 116, 0.3)',
+    overflowX: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
   },
   expanded: {
     borderLeft: `0.1rem solid ${colorPalette.unknown}`,
   },
   completed: {
-    backgroundColor: 'lightgreen',
+    backgroundColor: theme.palette.success.dark,
   },
   queued: {
     backgroundColor: theme.palette.warning.main,
   },
   active: {
-    backgroundColor: 'yellow',
+    backgroundColor: theme.palette.success.light,
   },
   failed: {
     backgroundColor: theme.palette.error.main,
   },
+  taskActor: {
+    alignSelf: 'center',
+  },
 }));
-
-// const listItems = allTasks.map((task) => {
-//   console.log(task);
-//   const statusDetails = TaskManager.formatStatus(task.status);
-//   const stateLabel = TaskManager.getStateLabel(task.state);
-//   return (
-//     <div key={task.task_id}>
-//       <div className={classes.accordionDetailLine}>
-//         <Typography variant="body1">TaskId: </Typography>
-//         <Typography variant="body1" noWrap>
-//           {task.task_id}
-//         </Typography>
-//       </div>
-//       <Divider />
-
-//       <div className={classes.accordionDetailLine}>
-//         <Typography variant="body1">State:</Typography>
-//         <Typography variant="body1">{stateLabel}</Typography>
-//       </div>
-//       <Divider />
-
-//       <div className={classes.accordionDetailLine}>
-//         <Typography variant="body1">Status:</Typography>
-//         <div>
-//           {statusDetails.map((detail) => {
-//             return (
-//               <>
-//                 <Typography variant="body1"> {detail}</Typography>
-//                 <Divider />
-//               </>
-//             );
-//           })}
-//         </div>
-//       </div>
-//       <Divider />
-
-//       <div className={classes.accordionDetailLine}>
-//         <Typography variant="body1">Submission Time:</Typography>
-//         <Typography variant="body1">{task.submission_time.sec}</Typography>
-//       </div>
-//       <Divider />
-
-//       <div className={classes.accordionDetailLine}>
-//         <Typography variant="body1">Start time:</Typography>
-//         <Typography variant="body1">{task.start_time.sec}</Typography>
-//       </div>
-//       <Divider />
-
-//       <div className={classes.accordionDetailLine}>
-//         <Typography variant="body1">End Time:</Typography>
-//         <Typography variant="body1">{task.end_time.sec}</Typography>
-//       </div>
-//       <div className={classes.buttonWrapper}>
-//         <Button className={classes.button} variant="contained" color="primary">
-//           {'Pause'}
-//         </Button>
-//       </div>
-//     </div>
-//   );
-// });

--- a/packages/dashboard/src/components/task-summary-panel-item.tsx
+++ b/packages/dashboard/src/components/task-summary-panel-item.tsx
@@ -9,64 +9,69 @@ interface TaskSummaryPanelItemProps {
   task: RomiCore.TaskSummary;
 }
 
-export const TaskSummaryPanelItem = (props: TaskSummaryPanelItemProps) => {
-  debug('render');
-  const { task } = props;
-  const classes = useStyles();
+export const TaskSummaryPanelItem = React.memo(
+  React.forwardRef(function (
+    props: TaskSummaryPanelItemProps,
+    ref: React.Ref<HTMLElement>,
+  ): React.ReactElement {
+    debug('render');
+    const { task } = props;
+    const classes = useStyles();
 
-  const statusDetails = TaskManager.formatStatus(task.status);
-  const stateLabel = TaskManager.getStateLabel(task.state);
+    const statusDetails = TaskManager.formatStatus(task.status);
+    const stateLabel = TaskManager.getStateLabel(task.state);
 
-  return (
-    <>
-      <div className={classes.accordionDetailLine}>
-        <Typography variant="body1">TaskId: </Typography>
-        <Typography variant="body1" noWrap>
-          {task.task_id}
-        </Typography>
-      </div>
-      <Divider />
-
-      <div className={classes.accordionDetailLine}>
-        <Typography variant="body1">State:</Typography>
-        <Typography variant="body1">{stateLabel}</Typography>
-      </div>
-      <Divider />
-
-      <div className={classes.accordionDetailLine}>
-        <Typography variant="body1">Status:</Typography>
-        <div>
-          {statusDetails.map((detail: string) => {
-            return (
-              <Typography variant="body1" key={detail}>
-                {' '}
-                {detail}
-              </Typography>
-            );
-          })}
+    return (
+      <>
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">TaskId: </Typography>
+          <Typography variant="body1" noWrap>
+            {task.task_id}
+          </Typography>
         </div>
-      </div>
-      <Divider />
+        <Divider />
 
-      <div className={classes.accordionDetailLine}>
-        <Typography variant="body1">Submission Time:</Typography>
-        <Typography variant="body1">{task.submission_time.sec}</Typography>
-      </div>
-      <Divider />
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">State:</Typography>
+          <Typography variant="body1">{stateLabel}</Typography>
+        </div>
+        <Divider />
 
-      <div className={classes.accordionDetailLine}>
-        <Typography variant="body1">Start time:</Typography>
-        <Typography variant="body1">{task.start_time.sec}</Typography>
-      </div>
-      <Divider />
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Status:</Typography>
+          <div>
+            {statusDetails.map((detail: string) => {
+              return (
+                <Typography variant="body1" key={detail}>
+                  {' '}
+                  {detail}
+                </Typography>
+              );
+            })}
+          </div>
+        </div>
+        <Divider />
 
-      <div className={classes.accordionDetailLine}>
-        <Typography variant="body1">End Time:</Typography>
-        <Typography variant="body1">{task.end_time.sec}</Typography>
-      </div>
-    </>
-  );
-};
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Submission Time:</Typography>
+          <Typography variant="body1">{task.submission_time.sec}</Typography>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Start time:</Typography>
+          <Typography variant="body1">{task.start_time.sec}</Typography>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">End Time:</Typography>
+          <Typography variant="body1">{task.end_time.sec}</Typography>
+        </div>
+      </>
+    );
+  }),
+);
 
 const useStyles = makeStyles((theme) => ({
   accordionDetailLine: {

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -51,7 +51,7 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
       selected={selected}
     >
       {allTasks.map((task) => (
-        <TaskSummaryPanelItem task={task} />
+        <TaskSummaryPanelItem task={task} key={task.task_id} />
       ))}
     </TreeView>
   );

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -220,17 +220,22 @@ const useStyles = makeStyles((theme: Theme) => ({
   expanded: {
     borderLeft: `0.1rem solid ${colorPalette.unknown}`,
   },
+  /**
+   * The idea is to maintain the same itemTree color depending on the task state even on selected.
+   * There are two styles API provided by the material-ui Tree library: `selected` and `label`.
+   * On a item select the library creates a class called `selected` that has precedence over the classes we could add using the API. So to override the background color of the `selected` class * We added `!important` to our custom styles that manage background color of the item tree.
+   */
   completed: {
-    backgroundColor: '#4E5453',
+    backgroundColor: '#4E5453 !important',
   },
   queued: {
-    backgroundColor: theme.palette.warning.main,
+    backgroundColor: theme.palette.warning.main + '!important',
   },
   active: {
-    backgroundColor: theme.palette.success.light,
+    backgroundColor: theme.palette.success.light + '!important',
   },
   failed: {
-    backgroundColor: theme.palette.error.main,
+    backgroundColor: theme.palette.error.main + '!important',
   },
   taskActor: {
     alignSelf: 'center',

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -7,6 +7,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { TaskSummaryPanelItem } from './task-summary-panel-item';
 import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
+import PauseCircleFilledIcon from '@material-ui/icons/PauseCircleFilled';
 import { colorPalette } from '../util/css-utils';
 import { TreeButtonGroup } from './tree-button-group';
 import { Theme } from '@material-ui/core/styles/createMuiTheme';
@@ -63,14 +64,19 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
   };
 
   const handleRestoreTasks = () => {
-    // Assigning another reference
-    let taskContentsTemp = Object.assign({}, taskContents);
-    Object.keys(savedTasksContent.current).forEach((element) => {
-      if (!(element in taskContents)) {
-        taskContentsTemp[element] = savedTasksContent.current[element];
-      }
+    setTaskContents((currentContent) => {
+      // Assigning another reference.
+      let taskContentsTemp = Object.assign({}, currentContent);
+      // We cannot assign directly the stored values to `currentContent` because it is updating
+      // the taskContents too, so when we set the taskContent new value with `setTaskContents`
+      // it'll no re-render because it'll not detect any changes.
+      Object.keys(savedTasksContent.current).forEach((element) => {
+        if (!(element in currentContent)) {
+          taskContentsTemp[element] = savedTasksContent.current[element];
+        }
+      });
+      return taskContentsTemp;
     });
-    setTaskContents(taskContentsTemp);
     savedTasksContent.current = {};
   };
 
@@ -115,15 +121,28 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
           label={
             <>
               <Typography variant="body1" noWrap>
-                <IconButton
-                  // TODO: replace onClick with the pause plans logic.
-                  onClick={(e) => {
-                    e.preventDefault();
-                    console.log('Not implemented');
-                  }}
-                >
-                  <PlayCircleFilledWhiteIcon />
-                </IconButton>
+                {task.state === RomiCore.TaskSummary.STATE_ACTIVE && (
+                  <IconButton
+                    // TODO: replace onClick with the pause plans logic.
+                    onClick={(e) => {
+                      e.preventDefault();
+                      console.log('Not implemented');
+                    }}
+                  >
+                    <PlayCircleFilledWhiteIcon />
+                  </IconButton>
+                )}
+                {task.state === RomiCore.TaskSummary.STATE_QUEUED && (
+                  <IconButton
+                    // TODO: replace onClick with the pause plans logic.
+                    onClick={(e) => {
+                      e.preventDefault();
+                      console.log('Not implemented');
+                    }}
+                  >
+                    <PauseCircleFilledIcon />
+                  </IconButton>
+                )}
                 {task.task_id}
               </Typography>
               {renderActor(task.status)}
@@ -136,11 +155,19 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
     };
 
     if (allTasks.length === 0) return;
-    let taskContentsTemp = Object.assign({}, taskContents);
-    allTasks.forEach((task) => {
-      taskContentsTemp[task.task_id] = renderTaskTreeItem(task);
+
+    setTaskContents((currentContent) => {
+      // Assigning another reference.
+      let taskContentsTemp = Object.assign({}, currentContent);
+      // We cannot assign directly the stored values to `currentContent` because it is updating
+      // the taskContents too, so when we set the taskContent new value with `setTaskContents`
+      // it'll no re-render because it'll not detect any changes.
+      allTasks.forEach((task) => {
+        taskContentsTemp[task.task_id] = renderTaskTreeItem(task);
+      });
+      return taskContentsTemp;
     });
-    setTaskContents(taskContentsTemp);
+
     // Ignoring dependency taskContents, it'll enter in a infinite loop
     // eslint-disable-next-line
   }, [allTasks]);

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -223,7 +223,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   /**
    * The idea is to maintain the same itemTree color depending on the task state even on selected.
    * There are two styles API provided by the material-ui Tree library: `selected` and `label`.
-   * On a item select the library creates a class called `selected` that has precedence over the classes we could add using the API. So to override the background color of the `selected` class * We added `!important` to our custom styles that manage background color of the item tree.
+   * On a item select the library creates a class called `selected` that has precedence over the
+   * classes we could add using the API. So to override the background color of the `selected`
+   * we added `!important` to our custom styles that manage background color of the item tree.
    */
   completed: {
     backgroundColor: '#4E5453 !important',

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { SpotlightValue } from './spotlight-value';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import { IconButton, makeStyles, Typography } from '@material-ui/core';
@@ -8,30 +7,31 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { TaskSummaryPanelItem } from './task-summary-panel-item';
 import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
-import TaskManager from '../managers/task-manager';
 import { colorPalette } from '../util/css-utils';
 import { TreeButtonGroup } from './tree-button-group';
 import { Theme } from '@material-ui/core/styles/createMuiTheme';
 
 const debug = Debug('OmniPanel:TaskSummaryPanel');
 
+// TODO: this is a hacky solution to get the actor from the task status,
+// this should be changed when then backend sends an actor on the
+// taskSummary message (we should use the actor provided by the message).
+// https://github.com/osrf/rmf_core/issues/205
+export const getActorFromStatus = (status: string) => {
+  // Gets the name of the robot if it has any
+  // eslint-disable-next-line
+  return status.match(/\[[A-Za-z]([a-zA-Z0-9\/]){3,}\]+/gi);
+};
+
 export interface TaskSummaryPanelProps {
   allTasks: RomiCore.TaskSummary[];
-  spotlight?: Readonly<SpotlightValue<string>>;
 }
 
 export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
   debug('task summary status panel render');
 
-  const { allTasks, spotlight } = props;
+  const { allTasks } = props;
   const classes = useStyles();
-
-  React.useEffect(() => {
-    if (!spotlight) {
-      return;
-    }
-    // TODO: spotlight
-  }, [spotlight]);
 
   const [taskContents, setTaskContents] = React.useState<{
     [key: string]: JSX.Element;
@@ -92,7 +92,7 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
   // Update Task list content
   React.useEffect(() => {
     const renderActor = (taskStatus: string): React.ReactElement | undefined => {
-      const actor = TaskManager.getActorFromStatus(taskStatus);
+      const actor = getActorFromStatus(taskStatus);
       if (!actor) return;
       return (
         <Typography variant="body1" className={classes.taskActor}>

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { SpotlightValue } from './spotlight-value';
+import Debug from 'debug';
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+import { Button, Divider, makeStyles, Typography } from '@material-ui/core';
+import TaskManager from '../managers/task-manager';
+
+const debug = Debug('OmniPanel:NegotiationsPanel');
+
+export interface TaskSummaryPanelProps {
+  allTasks: RomiCore.TaskSummary[];
+  spotlight?: Readonly<SpotlightValue<string>>;
+  transport?: Readonly<RomiCore.Transport>;
+}
+
+export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
+  debug('task summary status panel render');
+
+  const { allTasks, spotlight } = props;
+  const classes = useStyles();
+
+  React.useEffect(() => {
+    if (!spotlight) {
+      return;
+    }
+    // TODO: spotlight
+  }, [spotlight]);
+
+  const listItems = allTasks.map((task) => {
+    console.log(task);
+    const statusDetails = TaskManager.formatStatus(task.status);
+    const stateLabel = TaskManager.getStateLabel(task.state);
+    return (
+      <div key={task.task_id}>
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">TaskId: </Typography>
+          <Typography variant="body1" noWrap>
+            {task.task_id}
+          </Typography>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">State:</Typography>
+          <Typography variant="body1">{stateLabel}</Typography>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Status:</Typography>
+          <div>
+            {statusDetails.map((detail) => {
+              return (
+                <>
+                  <Typography variant="body1"> {detail}</Typography>
+                  <Divider />
+                </>
+              );
+            })}
+          </div>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Submission Time:</Typography>
+          <Typography variant="body1">{task.submission_time.sec}</Typography>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">Start time:</Typography>
+          <Typography variant="body1">{task.start_time.sec}</Typography>
+        </div>
+        <Divider />
+
+        <div className={classes.accordionDetailLine}>
+          <Typography variant="body1">End Time:</Typography>
+          <Typography variant="body1">{task.end_time.sec}</Typography>
+        </div>
+        <div className={classes.buttonWrapper}>
+          <Button className={classes.button} variant="contained" color="primary">
+            {'Pause'}
+          </Button>
+        </div>
+      </div>
+    );
+  });
+
+  return <>{listItems}</>;
+});
+
+const useStyles = makeStyles((theme) => ({
+  accordionDetailLine: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: theme.spacing(0.5),
+  },
+  button: {
+    width: '100%',
+  },
+  buttonWrapper: {
+    padding: '1rem 0.5rem',
+  },
+}));
+
+export default TaskSummaryPanel;

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -152,7 +152,7 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
           disableReset={allTasks.length === 0}
           disableClear={allTasks.length === 0}
           disableRestore={allTasks.length === 0}
-          handlResetClick={handleResetTasks}
+          handleResetClick={handleResetTasks}
           handleRestoreClick={handleRestoreTasks}
           handleClearClick={handleClearAllCurrTasks}
         />

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 import { SpotlightValue } from './spotlight-value';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
-import { makeStyles } from '@material-ui/core';
-import { TreeView } from '@material-ui/lab';
+import { IconButton, makeStyles, Typography } from '@material-ui/core';
+import { TreeItem, TreeView } from '@material-ui/lab';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { TaskSummaryPanelItem } from './task-summary-panel-item';
+import PlayCircleFilledWhiteIcon from '@material-ui/icons/PlayCircleFilledWhite';
+import TaskManager from '../managers/task-manager';
+import { colorPalette } from '../util/css-utils';
+
 const debug = Debug('OmniPanel:TaskSummaryPanel');
 
 export interface TaskSummaryPanelProps {
   allTasks: RomiCore.TaskSummary[];
   spotlight?: Readonly<SpotlightValue<string>>;
-  transport?: Readonly<RomiCore.Transport>;
 }
 
 export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
@@ -39,6 +42,31 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
     setSelected(nodeIds);
   };
 
+  const determineStyle = (state: number): string => {
+    switch (state) {
+      case RomiCore.TaskSummary.STATE_QUEUED:
+        return classes.queued;
+      case RomiCore.TaskSummary.STATE_ACTIVE:
+        return classes.active;
+      case RomiCore.TaskSummary.STATE_COMPLETED:
+        return classes.completed;
+      case RomiCore.TaskSummary.STATE_FAILED:
+        return classes.failed;
+      default:
+        return 'UNKNOWN';
+    }
+  };
+
+  const renderActor = (taskStatus: string) => {
+    const actor = TaskManager.getActorFromStatus(taskStatus);
+    if (!actor) return;
+    return (
+      <Typography variant="body1" className={classes.taskActor}>
+        {actor}
+      </Typography>
+    );
+  };
+
   return (
     <TreeView
       className={classes.root}
@@ -51,7 +79,35 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
       selected={selected}
     >
       {allTasks.map((task) => (
-        <TaskSummaryPanelItem task={task} key={task.task_id} />
+        <TreeItem
+          data-component="TreeItem"
+          nodeId={task.task_id}
+          key={task.task_id}
+          classes={{
+            label: `${determineStyle(task.state)} ${classes.labelContent}`,
+            root: classes.treeChildren,
+            expanded: classes.expanded,
+          }}
+          label={
+            <>
+              <Typography variant="body1" noWrap>
+                <IconButton
+                  // TODO: replace onClick with the pause plans logic.
+                  onClick={(e) => {
+                    e.preventDefault();
+                    console.log('Not implemented');
+                  }}
+                >
+                  <PlayCircleFilledWhiteIcon />
+                </IconButton>
+                {task.task_id}
+              </Typography>
+              {renderActor(task.status)}
+            </>
+          }
+        >
+          <TaskSummaryPanelItem task={task} key={task.task_id} />
+        </TreeItem>
       ))}
     </TreeView>
   );
@@ -60,6 +116,41 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: '1rem',
+  },
+
+  accordionDetailLine: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: theme.spacing(0.5),
+  },
+  treeChildren: {
+    margin: '0.5rem 0',
+  },
+  labelContent: {
+    padding: '0.5rem',
+    borderRadius: '0.5rem',
+    boxShadow: '0 0 25px 0 rgb(72, 94, 116, 0.3)',
+    overflowX: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  expanded: {
+    borderLeft: `0.1rem solid ${colorPalette.unknown}`,
+  },
+  completed: {
+    backgroundColor: theme.palette.success.dark,
+  },
+  queued: {
+    backgroundColor: theme.palette.warning.main,
+  },
+  active: {
+    backgroundColor: theme.palette.success.light,
+  },
+  failed: {
+    backgroundColor: theme.palette.error.main,
+  },
+  taskActor: {
+    alignSelf: 'center',
   },
 }));
 

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -117,7 +117,6 @@ const useStyles = makeStyles((theme) => ({
   root: {
     padding: '1rem',
   },
-
   accordionDetailLine: {
     display: 'flex',
     justifyContent: 'space-between',

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -59,22 +59,26 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
   };
 
   const handleClearAllCurrTasks = () => {
-    savedTasksContent.current = taskContents;
+    savedTasksContent.current = Object.assign({}, taskContents);
     setTaskContents({});
   };
 
   const handleRestoreTasks = () => {
+    // Adding this because the test interpreter cannot find the reference to `savedTasksContent current`
+    // inside the setTaskContents
+    const storedTasks = savedTasksContent.current;
     setTaskContents((currentContent) => {
       // Assigning another reference.
       let taskContentsTemp = Object.assign({}, currentContent);
       // We cannot assign directly the stored values to `currentContent` because it is updating
       // the taskContents too, so when we set the taskContent new value with `setTaskContents`
       // it'll no re-render because it'll not detect any changes.
-      Object.keys(savedTasksContent.current).forEach((element) => {
+      Object.keys(storedTasks).forEach((element) => {
         if (!(element in currentContent)) {
-          taskContentsTemp[element] = savedTasksContent.current[element];
+          taskContentsTemp[element] = storedTasks[element];
         }
       });
+      console.log(taskContentsTemp);
       return taskContentsTemp;
     });
     savedTasksContent.current = {};

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -58,7 +58,8 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
     setSelected('');
   };
 
-  // TODO: we need to synchronize this with a proper backend when it's ready. Now the completed // /// task will be flushed on a browser refresh because they are being saved in memory.
+  // TODO: we need to synchronize this with a proper backend when it's ready. Now the completed
+  // task will be flushed on a browser refresh because they are being saved in memory.
   const handleClearAllCurrTasks = () => {
     savedTasksContent.current = Object.assign({}, taskContents);
     setTaskContents({});
@@ -70,7 +71,7 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
     const storedTasks = savedTasksContent.current;
     setTaskContents((currentContent) => {
       // Assigning another reference.
-      let newTaskContents = Object.assign({}, currentContent);
+      const newTaskContents = Object.assign({}, currentContent);
       // We cannot assign directly the stored values to `currentContent` because it is updating
       // the taskContents too, so when we set the taskContent new value with `setTaskContents`
       // it'll no re-render because it'll not detect any changes.
@@ -155,7 +156,7 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
 
     setTaskContents((currentContent) => {
       // Assigning another reference.
-      let newTaskContents = Object.assign({}, currentContent);
+      const newTaskContents = Object.assign({}, currentContent);
       // We cannot assign directly the stored values to `currentContent` because it is updating
       // the taskContents too, so when we set the taskContent new value with `setTaskContents`
       // it'll no re-render because it'll not detect any changes.

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { SpotlightValue } from './spotlight-value';
 import Debug from 'debug';
 import * as RomiCore from '@osrf/romi-js-core-interfaces';
-import { Button, Divider, makeStyles, Typography } from '@material-ui/core';
-import TaskManager from '../managers/task-manager';
-
-const debug = Debug('OmniPanel:NegotiationsPanel');
+import { makeStyles } from '@material-ui/core';
+import { TreeView } from '@material-ui/lab';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import { TaskSummaryPanelItem } from './task-summary-panel-item';
+const debug = Debug('OmniPanel:TaskSummaryPanel');
 
 export interface TaskSummaryPanelProps {
   allTasks: RomiCore.TaskSummary[];
@@ -26,80 +28,38 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
     // TODO: spotlight
   }, [spotlight]);
 
-  const listItems = allTasks.map((task) => {
-    console.log(task);
-    const statusDetails = TaskManager.formatStatus(task.status);
-    const stateLabel = TaskManager.getStateLabel(task.state);
-    return (
-      <div key={task.task_id}>
-        <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">TaskId: </Typography>
-          <Typography variant="body1" noWrap>
-            {task.task_id}
-          </Typography>
-        </div>
-        <Divider />
+  const [expanded, setExpanded] = React.useState<string[]>([]);
+  const [selected, setSelected] = React.useState<string[]>([]);
 
-        <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">State:</Typography>
-          <Typography variant="body1">{stateLabel}</Typography>
-        </div>
-        <Divider />
+  const handleToggle = (event: React.ChangeEvent<{}>, nodeIds: string[]) => {
+    setExpanded(nodeIds);
+  };
 
-        <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">Status:</Typography>
-          <div>
-            {statusDetails.map((detail) => {
-              return (
-                <>
-                  <Typography variant="body1"> {detail}</Typography>
-                  <Divider />
-                </>
-              );
-            })}
-          </div>
-        </div>
-        <Divider />
+  const handleSelect = (event: React.ChangeEvent<{}>, nodeIds: string[]) => {
+    setSelected(nodeIds);
+  };
 
-        <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">Submission Time:</Typography>
-          <Typography variant="body1">{task.submission_time.sec}</Typography>
-        </div>
-        <Divider />
-
-        <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">Start time:</Typography>
-          <Typography variant="body1">{task.start_time.sec}</Typography>
-        </div>
-        <Divider />
-
-        <div className={classes.accordionDetailLine}>
-          <Typography variant="body1">End Time:</Typography>
-          <Typography variant="body1">{task.end_time.sec}</Typography>
-        </div>
-        <div className={classes.buttonWrapper}>
-          <Button className={classes.button} variant="contained" color="primary">
-            {'Pause'}
-          </Button>
-        </div>
-      </div>
-    );
-  });
-
-  return <>{listItems}</>;
+  return (
+    <TreeView
+      className={classes.root}
+      onNodeSelect={handleSelect}
+      onNodeToggle={handleToggle}
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpanded={['root']}
+      defaultExpandIcon={<ChevronRightIcon />}
+      expanded={expanded}
+      selected={selected}
+    >
+      {allTasks.map((task) => (
+        <TaskSummaryPanelItem task={task} />
+      ))}
+    </TreeView>
+  );
 });
 
 const useStyles = makeStyles((theme) => ({
-  accordionDetailLine: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    padding: theme.spacing(0.5),
-  },
-  button: {
-    width: '100%',
-  },
-  buttonWrapper: {
-    padding: '1rem 0.5rem',
+  root: {
+    padding: '1rem',
   },
 }));
 

--- a/packages/dashboard/src/components/task-summary-panel.tsx
+++ b/packages/dashboard/src/components/task-summary-panel.tsx
@@ -57,7 +57,7 @@ export const TaskSummaryPanel = React.memo((props: TaskSummaryPanelProps) => {
     }
   };
 
-  const renderActor = (taskStatus: string) => {
+  const renderActor = (taskStatus: string): React.ReactElement | undefined => {
     const actor = TaskManager.getActorFromStatus(taskStatus);
     if (!actor) return;
     return (

--- a/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel-item.test.tsx.snap
+++ b/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel-item.test.tsx.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Matches snapshot 1`] = `
+<Fragment>
+  <div
+    className="makeStyles-accordionDetailLine-1"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      TaskId: 
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      noWrap={true}
+      variant="body1"
+    >
+      af8faee9-84ca-41ea-8bb6-8493cc9f824c
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+  <WithStyles(ForwardRef(Divider)) />
+  <div
+    className="makeStyles-accordionDetailLine-1"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      State:
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      ACTIVE
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+  <WithStyles(ForwardRef(Divider)) />
+  <div
+    className="makeStyles-accordionDetailLine-1"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      Status:
+    </WithStyles(ForwardRef(Typography))>
+    <div>
+      <WithStyles(ForwardRef(Typography))
+        key="Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) "
+        variant="body1"
+      >
+         
+        Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -&gt; ( 6.26403 -3.51569  1.16864) 
+      </WithStyles(ForwardRef(Typography))>
+      <WithStyles(ForwardRef(Typography))
+        key=" Remaining phases: 1 "
+        variant="body1"
+      >
+         
+         Remaining phases: 1 
+      </WithStyles(ForwardRef(Typography))>
+      <WithStyles(ForwardRef(Typography))
+        key=" Remaining phases: 6"
+        variant="body1"
+      >
+         
+         Remaining phases: 6
+      </WithStyles(ForwardRef(Typography))>
+    </div>
+  </div>
+  <WithStyles(ForwardRef(Divider)) />
+  <div
+    className="makeStyles-accordionDetailLine-1"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      Submission Time:
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      0
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+  <WithStyles(ForwardRef(Divider)) />
+  <div
+    className="makeStyles-accordionDetailLine-1"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      Start time:
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      0
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+  <WithStyles(ForwardRef(Divider)) />
+  <div
+    className="makeStyles-accordionDetailLine-1"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      End Time:
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      0
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+</Fragment>
+`;

--- a/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel.test.tsx.snap
+++ b/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel.test.tsx.snap
@@ -1,956 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Matches snapshot 1`] = `
-<Memo()
-  allTasks={
+<WithStyles(ForwardRef(TreeView))
+  className="makeStyles-root-1"
+  defaultCollapseIcon={<UNDEFINED />}
+  defaultExpandIcon={<UNDEFINED />}
+  defaultExpanded={
     Array [
-      Object {
-        "end_time": Object {
-          "nanosec": 0,
-          "sec": 0,
-        },
-        "start_time": Object {
-          "nanosec": 0,
-          "sec": 0,
-        },
-        "state": 1,
-        "status": "Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
-        "submission_time": Object {
-          "nanosec": 0,
-          "sec": 0,
-        },
-        "task_id": "af8faee9-84ca-41ea-8bb6-8493cc9f824c",
-      },
-      Object {
-        "end_time": Object {
-          "nanosec": 0,
-          "sec": 0,
-        },
-        "start_time": Object {
-          "nanosec": 0,
-          "sec": 0,
-        },
-        "state": 1,
-        "status": "Moving [tinyRobot/tinyRobot2]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
-        "submission_time": Object {
-          "nanosec": 0,
-          "sec": 0,
-        },
-        "task_id": "am8faee9-84ca-41ea-8bb6-8493cc9f8249",
-      },
+      "root",
     ]
   }
+  expanded={Array []}
+  onNodeSelect={[Function]}
+  onNodeToggle={[Function]}
+  selected={Array []}
 >
-  <WithStyles(ForwardRef(TreeView))
-    className="makeStyles-root-1"
-    defaultCollapseIcon={<UNDEFINED />}
-    defaultExpandIcon={<UNDEFINED />}
-    defaultExpanded={
-      Array [
-        "root",
-      ]
+  <WithStyles(ForwardRef(TreeItem))
+    classes={
+      Object {
+        "expanded": "makeStyles-expanded-5",
+        "label": "makeStyles-active-8 makeStyles-labelContent-4",
+        "root": "makeStyles-treeChildren-3",
+      }
     }
-    expanded={Array []}
-    onNodeSelect={[Function]}
-    onNodeToggle={[Function]}
-    selected={Array []}
+    data-component="TreeItem"
+    key="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+    label={
+      <React.Fragment>
+        <ForwardRef(WithStyles)
+          noWrap={true}
+          variant="body1"
+        >
+          <ForwardRef(WithStyles)
+            onClick={[Function]}
+          >
+            <UNDEFINED />
+          </ForwardRef(WithStyles)>
+          af8faee9-84ca-41ea-8bb6-8493cc9f824c
+        </ForwardRef(WithStyles)>
+        <ForwardRef(WithStyles)
+          className="makeStyles-taskActor-10"
+          variant="body1"
+        >
+          [tinyRobot/tinyRobot1]
+        </ForwardRef(WithStyles)>
+      </React.Fragment>
+    }
+    nodeId="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
   >
-    <ForwardRef(TreeView)
-      className="makeStyles-root-1"
-      classes={
+    <TaskSummaryPanelItem
+      key="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+      task={
         Object {
-          "root": "MuiTreeView-root",
+          "end_time": Object {
+            "nanosec": 0,
+            "sec": 0,
+          },
+          "start_time": Object {
+            "nanosec": 0,
+            "sec": 0,
+          },
+          "state": 1,
+          "status": "Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
+          "submission_time": Object {
+            "nanosec": 0,
+            "sec": 0,
+          },
+          "task_id": "af8faee9-84ca-41ea-8bb6-8493cc9f824c",
         }
       }
-      defaultCollapseIcon={<UNDEFINED />}
-      defaultExpandIcon={<UNDEFINED />}
-      defaultExpanded={
-        Array [
-          "root",
-        ]
+    />
+  </WithStyles(ForwardRef(TreeItem))>
+  <WithStyles(ForwardRef(TreeItem))
+    classes={
+      Object {
+        "expanded": "makeStyles-expanded-5",
+        "label": "makeStyles-active-8 makeStyles-labelContent-4",
+        "root": "makeStyles-treeChildren-3",
       }
-      expanded={Array []}
-      onNodeSelect={[Function]}
-      onNodeToggle={[Function]}
-      selected={Array []}
-    >
-      <ul
-        aria-multiselectable={false}
-        className="MuiTreeView-root makeStyles-root-1"
-        role="tree"
-      >
-        <WithStyles(ForwardRef(TreeItem))
-          classes={
-            Object {
-              "expanded": "makeStyles-expanded-5",
-              "label": "makeStyles-active-8 makeStyles-labelContent-4",
-              "root": "makeStyles-treeChildren-3",
-            }
-          }
-          data-component="TreeItem"
-          key="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
-          label={
-            <React.Fragment>
-              <ForwardRef(WithStyles)
-                noWrap={true}
-                variant="body1"
-              >
-                <ForwardRef(WithStyles)
-                  onClick={[Function]}
-                >
-                  <UNDEFINED />
-                </ForwardRef(WithStyles)>
-                af8faee9-84ca-41ea-8bb6-8493cc9f824c
-              </ForwardRef(WithStyles)>
-              <ForwardRef(WithStyles)
-                className="makeStyles-taskActor-10"
-                variant="body1"
-              >
-                [tinyRobot/tinyRobot1]
-              </ForwardRef(WithStyles)>
-            </React.Fragment>
-          }
-          nodeId="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+    }
+    data-component="TreeItem"
+    key="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+    label={
+      <React.Fragment>
+        <ForwardRef(WithStyles)
+          noWrap={true}
+          variant="body1"
         >
-          <ForwardRef(TreeItem)
-            classes={
-              Object {
-                "content": "MuiTreeItem-content",
-                "expanded": "Mui-expanded makeStyles-expanded-5",
-                "group": "MuiTreeItem-group",
-                "iconContainer": "MuiTreeItem-iconContainer",
-                "label": "MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4",
-                "root": "MuiTreeItem-root makeStyles-treeChildren-3",
-                "selected": "Mui-selected",
-              }
-            }
-            data-component="TreeItem"
-            label={
-              <React.Fragment>
-                <ForwardRef(WithStyles)
-                  noWrap={true}
-                  variant="body1"
-                >
-                  <ForwardRef(WithStyles)
-                    onClick={[Function]}
-                  >
-                    <UNDEFINED />
-                  </ForwardRef(WithStyles)>
-                  af8faee9-84ca-41ea-8bb6-8493cc9f824c
-                </ForwardRef(WithStyles)>
-                <ForwardRef(WithStyles)
-                  className="makeStyles-taskActor-10"
-                  variant="body1"
-                >
-                  [tinyRobot/tinyRobot1]
-                </ForwardRef(WithStyles)>
-              </React.Fragment>
-            }
-            nodeId="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+          <ForwardRef(WithStyles)
+            onClick={[Function]}
           >
-            <li
-              aria-expanded={false}
-              className="MuiTreeItem-root makeStyles-treeChildren-3"
-              data-component="TreeItem"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              role="treeitem"
-              tabIndex={0}
-            >
-              <div
-                className="MuiTreeItem-content"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-              >
-                <div
-                  className="MuiTreeItem-iconContainer"
-                >
-                  <ForwardRef>
-                    <WithStyles(ForwardRef(SvgIcon))>
-                      <ForwardRef(SvgIcon)
-                        classes={
-                          Object {
-                            "colorAction": "MuiSvgIcon-colorAction",
-                            "colorDisabled": "MuiSvgIcon-colorDisabled",
-                            "colorError": "MuiSvgIcon-colorError",
-                            "colorPrimary": "MuiSvgIcon-colorPrimary",
-                            "colorSecondary": "MuiSvgIcon-colorSecondary",
-                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                            "root": "MuiSvgIcon-root",
-                          }
-                        }
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                          />
-                        </svg>
-                      </ForwardRef(SvgIcon)>
-                    </WithStyles(ForwardRef(SvgIcon))>
-                  </ForwardRef>
-                </div>
-                <WithStyles(ForwardRef(Typography))
-                  className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
-                  component="div"
-                >
-                  <ForwardRef(Typography)
-                    className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
-                    classes={
-                      Object {
-                        "alignCenter": "MuiTypography-alignCenter",
-                        "alignJustify": "MuiTypography-alignJustify",
-                        "alignLeft": "MuiTypography-alignLeft",
-                        "alignRight": "MuiTypography-alignRight",
-                        "body1": "MuiTypography-body1",
-                        "body2": "MuiTypography-body2",
-                        "button": "MuiTypography-button",
-                        "caption": "MuiTypography-caption",
-                        "colorError": "MuiTypography-colorError",
-                        "colorInherit": "MuiTypography-colorInherit",
-                        "colorPrimary": "MuiTypography-colorPrimary",
-                        "colorSecondary": "MuiTypography-colorSecondary",
-                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                        "displayBlock": "MuiTypography-displayBlock",
-                        "displayInline": "MuiTypography-displayInline",
-                        "gutterBottom": "MuiTypography-gutterBottom",
-                        "h1": "MuiTypography-h1",
-                        "h2": "MuiTypography-h2",
-                        "h3": "MuiTypography-h3",
-                        "h4": "MuiTypography-h4",
-                        "h5": "MuiTypography-h5",
-                        "h6": "MuiTypography-h6",
-                        "noWrap": "MuiTypography-noWrap",
-                        "overline": "MuiTypography-overline",
-                        "paragraph": "MuiTypography-paragraph",
-                        "root": "MuiTypography-root",
-                        "srOnly": "MuiTypography-srOnly",
-                        "subtitle1": "MuiTypography-subtitle1",
-                        "subtitle2": "MuiTypography-subtitle2",
-                      }
-                    }
-                    component="div"
-                  >
-                    <div
-                      className="MuiTypography-root MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4 MuiTypography-body1"
-                    >
-                      <WithStyles(ForwardRef(Typography))
-                        noWrap={true}
-                        variant="body1"
-                      >
-                        <ForwardRef(Typography)
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          noWrap={true}
-                          variant="body1"
-                        >
-                          <p
-                            className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
-                          >
-                            <WithStyles(ForwardRef(IconButton))
-                              onClick={[Function]}
-                            >
-                              <ForwardRef(IconButton)
-                                classes={
-                                  Object {
-                                    "colorInherit": "MuiIconButton-colorInherit",
-                                    "colorPrimary": "MuiIconButton-colorPrimary",
-                                    "colorSecondary": "MuiIconButton-colorSecondary",
-                                    "disabled": "Mui-disabled",
-                                    "edgeEnd": "MuiIconButton-edgeEnd",
-                                    "edgeStart": "MuiIconButton-edgeStart",
-                                    "label": "MuiIconButton-label",
-                                    "root": "MuiIconButton-root",
-                                    "sizeSmall": "MuiIconButton-sizeSmall",
-                                  }
-                                }
-                                onClick={[Function]}
-                              >
-                                <WithStyles(ForwardRef(ButtonBase))
-                                  centerRipple={true}
-                                  className="MuiIconButton-root"
-                                  disabled={false}
-                                  focusRipple={true}
-                                  onClick={[Function]}
-                                >
-                                  <ForwardRef(ButtonBase)
-                                    centerRipple={true}
-                                    className="MuiIconButton-root"
-                                    classes={
-                                      Object {
-                                        "disabled": "Mui-disabled",
-                                        "focusVisible": "Mui-focusVisible",
-                                        "root": "MuiButtonBase-root",
-                                      }
-                                    }
-                                    disabled={false}
-                                    focusRipple={true}
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      className="MuiButtonBase-root MuiIconButton-root"
-                                      disabled={false}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onDragLeave={[Function]}
-                                      onFocus={[Function]}
-                                      onKeyDown={[Function]}
-                                      onKeyUp={[Function]}
-                                      onMouseDown={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onMouseUp={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
-                                      tabIndex={0}
-                                      type="button"
-                                    >
-                                      <span
-                                        className="MuiIconButton-label"
-                                      >
-                                        <ForwardRef>
-                                          <WithStyles(ForwardRef(SvgIcon))>
-                                            <ForwardRef(SvgIcon)
-                                              classes={
-                                                Object {
-                                                  "colorAction": "MuiSvgIcon-colorAction",
-                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                  "colorError": "MuiSvgIcon-colorError",
-                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                  "root": "MuiSvgIcon-root",
-                                                }
-                                              }
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="MuiSvgIcon-root"
-                                                focusable="false"
-                                                viewBox="0 0 24 24"
-                                              >
-                                                <path
-                                                  d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"
-                                                  transform="scale(0.5, 0.5)"
-                                                />
-                                              </svg>
-                                            </ForwardRef(SvgIcon)>
-                                          </WithStyles(ForwardRef(SvgIcon))>
-                                        </ForwardRef>
-                                      </span>
-                                      <WithStyles(memo)
-                                        center={true}
-                                      >
-                                        <ForwardRef(TouchRipple)
-                                          center={true}
-                                          classes={
-                                            Object {
-                                              "child": "MuiTouchRipple-child",
-                                              "childLeaving": "MuiTouchRipple-childLeaving",
-                                              "childPulsate": "MuiTouchRipple-childPulsate",
-                                              "ripple": "MuiTouchRipple-ripple",
-                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                              "root": "MuiTouchRipple-root",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="MuiTouchRipple-root"
-                                          >
-                                            <TransitionGroup
-                                              childFactory={[Function]}
-                                              component={null}
-                                              exit={true}
-                                            />
-                                          </span>
-                                        </ForwardRef(TouchRipple)>
-                                      </WithStyles(memo)>
-                                    </button>
-                                  </ForwardRef(ButtonBase)>
-                                </WithStyles(ForwardRef(ButtonBase))>
-                              </ForwardRef(IconButton)>
-                            </WithStyles(ForwardRef(IconButton))>
-                            af8faee9-84ca-41ea-8bb6-8493cc9f824c
-                          </p>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                      <WithStyles(ForwardRef(Typography))
-                        className="makeStyles-taskActor-10"
-                        variant="body1"
-                      >
-                        <ForwardRef(Typography)
-                          className="makeStyles-taskActor-10"
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          variant="body1"
-                        >
-                          <p
-                            className="MuiTypography-root makeStyles-taskActor-10 MuiTypography-body1"
-                          >
-                            [tinyRobot/tinyRobot1]
-                          </p>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                    </div>
-                  </ForwardRef(Typography)>
-                </WithStyles(ForwardRef(Typography))>
-              </div>
-              <WithStyles(ForwardRef(Collapse))
-                className="MuiTreeItem-group"
-                component="ul"
-                in={false}
-                role="group"
-                unmountOnExit={true}
-              >
-                <ForwardRef(Collapse)
-                  className="MuiTreeItem-group"
-                  classes={
-                    Object {
-                      "container": "MuiCollapse-container",
-                      "entered": "MuiCollapse-entered",
-                      "hidden": "MuiCollapse-hidden",
-                      "wrapper": "MuiCollapse-wrapper",
-                      "wrapperInner": "MuiCollapse-wrapperInner",
-                    }
-                  }
-                  component="ul"
-                  in={false}
-                  role="group"
-                  unmountOnExit={true}
-                >
-                  <Transition
-                    addEndListener={[Function]}
-                    appear={false}
-                    enter={true}
-                    exit={true}
-                    in={false}
-                    mountOnEnter={false}
-                    onEnter={[Function]}
-                    onEntered={[Function]}
-                    onEntering={[Function]}
-                    onExit={[Function]}
-                    onExited={[Function]}
-                    onExiting={[Function]}
-                    role="group"
-                    timeout={300}
-                    unmountOnExit={true}
-                  />
-                </ForwardRef(Collapse)>
-              </WithStyles(ForwardRef(Collapse))>
-            </li>
-          </ForwardRef(TreeItem)>
-        </WithStyles(ForwardRef(TreeItem))>
-        <WithStyles(ForwardRef(TreeItem))
-          classes={
-            Object {
-              "expanded": "makeStyles-expanded-5",
-              "label": "makeStyles-active-8 makeStyles-labelContent-4",
-              "root": "makeStyles-treeChildren-3",
-            }
-          }
-          data-component="TreeItem"
-          key="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
-          label={
-            <React.Fragment>
-              <ForwardRef(WithStyles)
-                noWrap={true}
-                variant="body1"
-              >
-                <ForwardRef(WithStyles)
-                  onClick={[Function]}
-                >
-                  <UNDEFINED />
-                </ForwardRef(WithStyles)>
-                am8faee9-84ca-41ea-8bb6-8493cc9f8249
-              </ForwardRef(WithStyles)>
-              <ForwardRef(WithStyles)
-                className="makeStyles-taskActor-10"
-                variant="body1"
-              >
-                [tinyRobot/tinyRobot2]
-              </ForwardRef(WithStyles)>
-            </React.Fragment>
-          }
-          nodeId="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+            <UNDEFINED />
+          </ForwardRef(WithStyles)>
+          am8faee9-84ca-41ea-8bb6-8493cc9f8249
+        </ForwardRef(WithStyles)>
+        <ForwardRef(WithStyles)
+          className="makeStyles-taskActor-10"
+          variant="body1"
         >
-          <ForwardRef(TreeItem)
-            classes={
-              Object {
-                "content": "MuiTreeItem-content",
-                "expanded": "Mui-expanded makeStyles-expanded-5",
-                "group": "MuiTreeItem-group",
-                "iconContainer": "MuiTreeItem-iconContainer",
-                "label": "MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4",
-                "root": "MuiTreeItem-root makeStyles-treeChildren-3",
-                "selected": "Mui-selected",
-              }
-            }
-            data-component="TreeItem"
-            label={
-              <React.Fragment>
-                <ForwardRef(WithStyles)
-                  noWrap={true}
-                  variant="body1"
-                >
-                  <ForwardRef(WithStyles)
-                    onClick={[Function]}
-                  >
-                    <UNDEFINED />
-                  </ForwardRef(WithStyles)>
-                  am8faee9-84ca-41ea-8bb6-8493cc9f8249
-                </ForwardRef(WithStyles)>
-                <ForwardRef(WithStyles)
-                  className="makeStyles-taskActor-10"
-                  variant="body1"
-                >
-                  [tinyRobot/tinyRobot2]
-                </ForwardRef(WithStyles)>
-              </React.Fragment>
-            }
-            nodeId="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
-          >
-            <li
-              aria-expanded={false}
-              className="MuiTreeItem-root makeStyles-treeChildren-3"
-              data-component="TreeItem"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              role="treeitem"
-              tabIndex={-1}
-            >
-              <div
-                className="MuiTreeItem-content"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-              >
-                <div
-                  className="MuiTreeItem-iconContainer"
-                >
-                  <ForwardRef>
-                    <WithStyles(ForwardRef(SvgIcon))>
-                      <ForwardRef(SvgIcon)
-                        classes={
-                          Object {
-                            "colorAction": "MuiSvgIcon-colorAction",
-                            "colorDisabled": "MuiSvgIcon-colorDisabled",
-                            "colorError": "MuiSvgIcon-colorError",
-                            "colorPrimary": "MuiSvgIcon-colorPrimary",
-                            "colorSecondary": "MuiSvgIcon-colorSecondary",
-                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                            "root": "MuiSvgIcon-root",
-                          }
-                        }
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                          />
-                        </svg>
-                      </ForwardRef(SvgIcon)>
-                    </WithStyles(ForwardRef(SvgIcon))>
-                  </ForwardRef>
-                </div>
-                <WithStyles(ForwardRef(Typography))
-                  className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
-                  component="div"
-                >
-                  <ForwardRef(Typography)
-                    className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
-                    classes={
-                      Object {
-                        "alignCenter": "MuiTypography-alignCenter",
-                        "alignJustify": "MuiTypography-alignJustify",
-                        "alignLeft": "MuiTypography-alignLeft",
-                        "alignRight": "MuiTypography-alignRight",
-                        "body1": "MuiTypography-body1",
-                        "body2": "MuiTypography-body2",
-                        "button": "MuiTypography-button",
-                        "caption": "MuiTypography-caption",
-                        "colorError": "MuiTypography-colorError",
-                        "colorInherit": "MuiTypography-colorInherit",
-                        "colorPrimary": "MuiTypography-colorPrimary",
-                        "colorSecondary": "MuiTypography-colorSecondary",
-                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                        "displayBlock": "MuiTypography-displayBlock",
-                        "displayInline": "MuiTypography-displayInline",
-                        "gutterBottom": "MuiTypography-gutterBottom",
-                        "h1": "MuiTypography-h1",
-                        "h2": "MuiTypography-h2",
-                        "h3": "MuiTypography-h3",
-                        "h4": "MuiTypography-h4",
-                        "h5": "MuiTypography-h5",
-                        "h6": "MuiTypography-h6",
-                        "noWrap": "MuiTypography-noWrap",
-                        "overline": "MuiTypography-overline",
-                        "paragraph": "MuiTypography-paragraph",
-                        "root": "MuiTypography-root",
-                        "srOnly": "MuiTypography-srOnly",
-                        "subtitle1": "MuiTypography-subtitle1",
-                        "subtitle2": "MuiTypography-subtitle2",
-                      }
-                    }
-                    component="div"
-                  >
-                    <div
-                      className="MuiTypography-root MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4 MuiTypography-body1"
-                    >
-                      <WithStyles(ForwardRef(Typography))
-                        noWrap={true}
-                        variant="body1"
-                      >
-                        <ForwardRef(Typography)
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          noWrap={true}
-                          variant="body1"
-                        >
-                          <p
-                            className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
-                          >
-                            <WithStyles(ForwardRef(IconButton))
-                              onClick={[Function]}
-                            >
-                              <ForwardRef(IconButton)
-                                classes={
-                                  Object {
-                                    "colorInherit": "MuiIconButton-colorInherit",
-                                    "colorPrimary": "MuiIconButton-colorPrimary",
-                                    "colorSecondary": "MuiIconButton-colorSecondary",
-                                    "disabled": "Mui-disabled",
-                                    "edgeEnd": "MuiIconButton-edgeEnd",
-                                    "edgeStart": "MuiIconButton-edgeStart",
-                                    "label": "MuiIconButton-label",
-                                    "root": "MuiIconButton-root",
-                                    "sizeSmall": "MuiIconButton-sizeSmall",
-                                  }
-                                }
-                                onClick={[Function]}
-                              >
-                                <WithStyles(ForwardRef(ButtonBase))
-                                  centerRipple={true}
-                                  className="MuiIconButton-root"
-                                  disabled={false}
-                                  focusRipple={true}
-                                  onClick={[Function]}
-                                >
-                                  <ForwardRef(ButtonBase)
-                                    centerRipple={true}
-                                    className="MuiIconButton-root"
-                                    classes={
-                                      Object {
-                                        "disabled": "Mui-disabled",
-                                        "focusVisible": "Mui-focusVisible",
-                                        "root": "MuiButtonBase-root",
-                                      }
-                                    }
-                                    disabled={false}
-                                    focusRipple={true}
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      className="MuiButtonBase-root MuiIconButton-root"
-                                      disabled={false}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onDragLeave={[Function]}
-                                      onFocus={[Function]}
-                                      onKeyDown={[Function]}
-                                      onKeyUp={[Function]}
-                                      onMouseDown={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onMouseUp={[Function]}
-                                      onTouchEnd={[Function]}
-                                      onTouchMove={[Function]}
-                                      onTouchStart={[Function]}
-                                      tabIndex={0}
-                                      type="button"
-                                    >
-                                      <span
-                                        className="MuiIconButton-label"
-                                      >
-                                        <ForwardRef>
-                                          <WithStyles(ForwardRef(SvgIcon))>
-                                            <ForwardRef(SvgIcon)
-                                              classes={
-                                                Object {
-                                                  "colorAction": "MuiSvgIcon-colorAction",
-                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                  "colorError": "MuiSvgIcon-colorError",
-                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                  "root": "MuiSvgIcon-root",
-                                                }
-                                              }
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="MuiSvgIcon-root"
-                                                focusable="false"
-                                                viewBox="0 0 24 24"
-                                              >
-                                                <path
-                                                  d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"
-                                                  transform="scale(0.5, 0.5)"
-                                                />
-                                              </svg>
-                                            </ForwardRef(SvgIcon)>
-                                          </WithStyles(ForwardRef(SvgIcon))>
-                                        </ForwardRef>
-                                      </span>
-                                      <WithStyles(memo)
-                                        center={true}
-                                      >
-                                        <ForwardRef(TouchRipple)
-                                          center={true}
-                                          classes={
-                                            Object {
-                                              "child": "MuiTouchRipple-child",
-                                              "childLeaving": "MuiTouchRipple-childLeaving",
-                                              "childPulsate": "MuiTouchRipple-childPulsate",
-                                              "ripple": "MuiTouchRipple-ripple",
-                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                              "root": "MuiTouchRipple-root",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="MuiTouchRipple-root"
-                                          >
-                                            <TransitionGroup
-                                              childFactory={[Function]}
-                                              component={null}
-                                              exit={true}
-                                            />
-                                          </span>
-                                        </ForwardRef(TouchRipple)>
-                                      </WithStyles(memo)>
-                                    </button>
-                                  </ForwardRef(ButtonBase)>
-                                </WithStyles(ForwardRef(ButtonBase))>
-                              </ForwardRef(IconButton)>
-                            </WithStyles(ForwardRef(IconButton))>
-                            am8faee9-84ca-41ea-8bb6-8493cc9f8249
-                          </p>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                      <WithStyles(ForwardRef(Typography))
-                        className="makeStyles-taskActor-10"
-                        variant="body1"
-                      >
-                        <ForwardRef(Typography)
-                          className="makeStyles-taskActor-10"
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          variant="body1"
-                        >
-                          <p
-                            className="MuiTypography-root makeStyles-taskActor-10 MuiTypography-body1"
-                          >
-                            [tinyRobot/tinyRobot2]
-                          </p>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                    </div>
-                  </ForwardRef(Typography)>
-                </WithStyles(ForwardRef(Typography))>
-              </div>
-              <WithStyles(ForwardRef(Collapse))
-                className="MuiTreeItem-group"
-                component="ul"
-                in={false}
-                role="group"
-                unmountOnExit={true}
-              >
-                <ForwardRef(Collapse)
-                  className="MuiTreeItem-group"
-                  classes={
-                    Object {
-                      "container": "MuiCollapse-container",
-                      "entered": "MuiCollapse-entered",
-                      "hidden": "MuiCollapse-hidden",
-                      "wrapper": "MuiCollapse-wrapper",
-                      "wrapperInner": "MuiCollapse-wrapperInner",
-                    }
-                  }
-                  component="ul"
-                  in={false}
-                  role="group"
-                  unmountOnExit={true}
-                >
-                  <Transition
-                    addEndListener={[Function]}
-                    appear={false}
-                    enter={true}
-                    exit={true}
-                    in={false}
-                    mountOnEnter={false}
-                    onEnter={[Function]}
-                    onEntered={[Function]}
-                    onEntering={[Function]}
-                    onExit={[Function]}
-                    onExited={[Function]}
-                    onExiting={[Function]}
-                    role="group"
-                    timeout={300}
-                    unmountOnExit={true}
-                  />
-                </ForwardRef(Collapse)>
-              </WithStyles(ForwardRef(Collapse))>
-            </li>
-          </ForwardRef(TreeItem)>
-        </WithStyles(ForwardRef(TreeItem))>
-      </ul>
-    </ForwardRef(TreeView)>
-  </WithStyles(ForwardRef(TreeView))>
-</Memo()>
+          [tinyRobot/tinyRobot2]
+        </ForwardRef(WithStyles)>
+      </React.Fragment>
+    }
+    nodeId="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+  >
+    <TaskSummaryPanelItem
+      key="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+      task={
+        Object {
+          "end_time": Object {
+            "nanosec": 0,
+            "sec": 0,
+          },
+          "start_time": Object {
+            "nanosec": 0,
+            "sec": 0,
+          },
+          "state": 1,
+          "status": "Moving [tinyRobot/tinyRobot2]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
+          "submission_time": Object {
+            "nanosec": 0,
+            "sec": 0,
+          },
+          "task_id": "am8faee9-84ca-41ea-8bb6-8493cc9f8249",
+        }
+      }
+    />
+  </WithStyles(ForwardRef(TreeItem))>
+</WithStyles(ForwardRef(TreeView))>
 `;

--- a/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel.test.tsx.snap
+++ b/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel.test.tsx.snap
@@ -1,0 +1,956 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Matches snapshot 1`] = `
+<Memo()
+  allTasks={
+    Array [
+      Object {
+        "end_time": Object {
+          "nanosec": 0,
+          "sec": 0,
+        },
+        "start_time": Object {
+          "nanosec": 0,
+          "sec": 0,
+        },
+        "state": 1,
+        "status": "Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
+        "submission_time": Object {
+          "nanosec": 0,
+          "sec": 0,
+        },
+        "task_id": "af8faee9-84ca-41ea-8bb6-8493cc9f824c",
+      },
+      Object {
+        "end_time": Object {
+          "nanosec": 0,
+          "sec": 0,
+        },
+        "start_time": Object {
+          "nanosec": 0,
+          "sec": 0,
+        },
+        "state": 1,
+        "status": "Moving [tinyRobot/tinyRobot2]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
+        "submission_time": Object {
+          "nanosec": 0,
+          "sec": 0,
+        },
+        "task_id": "am8faee9-84ca-41ea-8bb6-8493cc9f8249",
+      },
+    ]
+  }
+>
+  <WithStyles(ForwardRef(TreeView))
+    className="makeStyles-root-1"
+    defaultCollapseIcon={<UNDEFINED />}
+    defaultExpandIcon={<UNDEFINED />}
+    defaultExpanded={
+      Array [
+        "root",
+      ]
+    }
+    expanded={Array []}
+    onNodeSelect={[Function]}
+    onNodeToggle={[Function]}
+    selected={Array []}
+  >
+    <ForwardRef(TreeView)
+      className="makeStyles-root-1"
+      classes={
+        Object {
+          "root": "MuiTreeView-root",
+        }
+      }
+      defaultCollapseIcon={<UNDEFINED />}
+      defaultExpandIcon={<UNDEFINED />}
+      defaultExpanded={
+        Array [
+          "root",
+        ]
+      }
+      expanded={Array []}
+      onNodeSelect={[Function]}
+      onNodeToggle={[Function]}
+      selected={Array []}
+    >
+      <ul
+        aria-multiselectable={false}
+        className="MuiTreeView-root makeStyles-root-1"
+        role="tree"
+      >
+        <WithStyles(ForwardRef(TreeItem))
+          classes={
+            Object {
+              "expanded": "makeStyles-expanded-5",
+              "label": "makeStyles-active-8 makeStyles-labelContent-4",
+              "root": "makeStyles-treeChildren-3",
+            }
+          }
+          data-component="TreeItem"
+          key="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+          label={
+            <React.Fragment>
+              <ForwardRef(WithStyles)
+                noWrap={true}
+                variant="body1"
+              >
+                <ForwardRef(WithStyles)
+                  onClick={[Function]}
+                >
+                  <UNDEFINED />
+                </ForwardRef(WithStyles)>
+                af8faee9-84ca-41ea-8bb6-8493cc9f824c
+              </ForwardRef(WithStyles)>
+              <ForwardRef(WithStyles)
+                className="makeStyles-taskActor-10"
+                variant="body1"
+              >
+                [tinyRobot/tinyRobot1]
+              </ForwardRef(WithStyles)>
+            </React.Fragment>
+          }
+          nodeId="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+        >
+          <ForwardRef(TreeItem)
+            classes={
+              Object {
+                "content": "MuiTreeItem-content",
+                "expanded": "Mui-expanded makeStyles-expanded-5",
+                "group": "MuiTreeItem-group",
+                "iconContainer": "MuiTreeItem-iconContainer",
+                "label": "MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4",
+                "root": "MuiTreeItem-root makeStyles-treeChildren-3",
+                "selected": "Mui-selected",
+              }
+            }
+            data-component="TreeItem"
+            label={
+              <React.Fragment>
+                <ForwardRef(WithStyles)
+                  noWrap={true}
+                  variant="body1"
+                >
+                  <ForwardRef(WithStyles)
+                    onClick={[Function]}
+                  >
+                    <UNDEFINED />
+                  </ForwardRef(WithStyles)>
+                  af8faee9-84ca-41ea-8bb6-8493cc9f824c
+                </ForwardRef(WithStyles)>
+                <ForwardRef(WithStyles)
+                  className="makeStyles-taskActor-10"
+                  variant="body1"
+                >
+                  [tinyRobot/tinyRobot1]
+                </ForwardRef(WithStyles)>
+              </React.Fragment>
+            }
+            nodeId="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+          >
+            <li
+              aria-expanded={false}
+              className="MuiTreeItem-root makeStyles-treeChildren-3"
+              data-component="TreeItem"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="MuiTreeItem-content"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+              >
+                <div
+                  className="MuiTreeItem-iconContainer"
+                >
+                  <ForwardRef>
+                    <WithStyles(ForwardRef(SvgIcon))>
+                      <ForwardRef(SvgIcon)
+                        classes={
+                          Object {
+                            "colorAction": "MuiSvgIcon-colorAction",
+                            "colorDisabled": "MuiSvgIcon-colorDisabled",
+                            "colorError": "MuiSvgIcon-colorError",
+                            "colorPrimary": "MuiSvgIcon-colorPrimary",
+                            "colorSecondary": "MuiSvgIcon-colorSecondary",
+                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                            "root": "MuiSvgIcon-root",
+                          }
+                        }
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                          />
+                        </svg>
+                      </ForwardRef(SvgIcon)>
+                    </WithStyles(ForwardRef(SvgIcon))>
+                  </ForwardRef>
+                </div>
+                <WithStyles(ForwardRef(Typography))
+                  className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
+                  component="div"
+                >
+                  <ForwardRef(Typography)
+                    className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
+                    classes={
+                      Object {
+                        "alignCenter": "MuiTypography-alignCenter",
+                        "alignJustify": "MuiTypography-alignJustify",
+                        "alignLeft": "MuiTypography-alignLeft",
+                        "alignRight": "MuiTypography-alignRight",
+                        "body1": "MuiTypography-body1",
+                        "body2": "MuiTypography-body2",
+                        "button": "MuiTypography-button",
+                        "caption": "MuiTypography-caption",
+                        "colorError": "MuiTypography-colorError",
+                        "colorInherit": "MuiTypography-colorInherit",
+                        "colorPrimary": "MuiTypography-colorPrimary",
+                        "colorSecondary": "MuiTypography-colorSecondary",
+                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                        "displayBlock": "MuiTypography-displayBlock",
+                        "displayInline": "MuiTypography-displayInline",
+                        "gutterBottom": "MuiTypography-gutterBottom",
+                        "h1": "MuiTypography-h1",
+                        "h2": "MuiTypography-h2",
+                        "h3": "MuiTypography-h3",
+                        "h4": "MuiTypography-h4",
+                        "h5": "MuiTypography-h5",
+                        "h6": "MuiTypography-h6",
+                        "noWrap": "MuiTypography-noWrap",
+                        "overline": "MuiTypography-overline",
+                        "paragraph": "MuiTypography-paragraph",
+                        "root": "MuiTypography-root",
+                        "srOnly": "MuiTypography-srOnly",
+                        "subtitle1": "MuiTypography-subtitle1",
+                        "subtitle2": "MuiTypography-subtitle2",
+                      }
+                    }
+                    component="div"
+                  >
+                    <div
+                      className="MuiTypography-root MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4 MuiTypography-body1"
+                    >
+                      <WithStyles(ForwardRef(Typography))
+                        noWrap={true}
+                        variant="body1"
+                      >
+                        <ForwardRef(Typography)
+                          classes={
+                            Object {
+                              "alignCenter": "MuiTypography-alignCenter",
+                              "alignJustify": "MuiTypography-alignJustify",
+                              "alignLeft": "MuiTypography-alignLeft",
+                              "alignRight": "MuiTypography-alignRight",
+                              "body1": "MuiTypography-body1",
+                              "body2": "MuiTypography-body2",
+                              "button": "MuiTypography-button",
+                              "caption": "MuiTypography-caption",
+                              "colorError": "MuiTypography-colorError",
+                              "colorInherit": "MuiTypography-colorInherit",
+                              "colorPrimary": "MuiTypography-colorPrimary",
+                              "colorSecondary": "MuiTypography-colorSecondary",
+                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                              "displayBlock": "MuiTypography-displayBlock",
+                              "displayInline": "MuiTypography-displayInline",
+                              "gutterBottom": "MuiTypography-gutterBottom",
+                              "h1": "MuiTypography-h1",
+                              "h2": "MuiTypography-h2",
+                              "h3": "MuiTypography-h3",
+                              "h4": "MuiTypography-h4",
+                              "h5": "MuiTypography-h5",
+                              "h6": "MuiTypography-h6",
+                              "noWrap": "MuiTypography-noWrap",
+                              "overline": "MuiTypography-overline",
+                              "paragraph": "MuiTypography-paragraph",
+                              "root": "MuiTypography-root",
+                              "srOnly": "MuiTypography-srOnly",
+                              "subtitle1": "MuiTypography-subtitle1",
+                              "subtitle2": "MuiTypography-subtitle2",
+                            }
+                          }
+                          noWrap={true}
+                          variant="body1"
+                        >
+                          <p
+                            className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                          >
+                            <WithStyles(ForwardRef(IconButton))
+                              onClick={[Function]}
+                            >
+                              <ForwardRef(IconButton)
+                                classes={
+                                  Object {
+                                    "colorInherit": "MuiIconButton-colorInherit",
+                                    "colorPrimary": "MuiIconButton-colorPrimary",
+                                    "colorSecondary": "MuiIconButton-colorSecondary",
+                                    "disabled": "Mui-disabled",
+                                    "edgeEnd": "MuiIconButton-edgeEnd",
+                                    "edgeStart": "MuiIconButton-edgeStart",
+                                    "label": "MuiIconButton-label",
+                                    "root": "MuiIconButton-root",
+                                    "sizeSmall": "MuiIconButton-sizeSmall",
+                                  }
+                                }
+                                onClick={[Function]}
+                              >
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  centerRipple={true}
+                                  className="MuiIconButton-root"
+                                  disabled={false}
+                                  focusRipple={true}
+                                  onClick={[Function]}
+                                >
+                                  <ForwardRef(ButtonBase)
+                                    centerRipple={true}
+                                    className="MuiIconButton-root"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    disabled={false}
+                                    focusRipple={true}
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="MuiButtonBase-root MuiIconButton-root"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      tabIndex={0}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="MuiIconButton-label"
+                                      >
+                                        <ForwardRef>
+                                          <WithStyles(ForwardRef(SvgIcon))>
+                                            <ForwardRef(SvgIcon)
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="MuiSvgIcon-root"
+                                                focusable="false"
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"
+                                                  transform="scale(0.5, 0.5)"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </span>
+                                      <WithStyles(memo)
+                                        center={true}
+                                      >
+                                        <ForwardRef(TouchRipple)
+                                          center={true}
+                                          classes={
+                                            Object {
+                                              "child": "MuiTouchRipple-child",
+                                              "childLeaving": "MuiTouchRipple-childLeaving",
+                                              "childPulsate": "MuiTouchRipple-childPulsate",
+                                              "ripple": "MuiTouchRipple-ripple",
+                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                              "root": "MuiTouchRipple-root",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="MuiTouchRipple-root"
+                                          >
+                                            <TransitionGroup
+                                              childFactory={[Function]}
+                                              component={null}
+                                              exit={true}
+                                            />
+                                          </span>
+                                        </ForwardRef(TouchRipple)>
+                                      </WithStyles(memo)>
+                                    </button>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(IconButton)>
+                            </WithStyles(ForwardRef(IconButton))>
+                            af8faee9-84ca-41ea-8bb6-8493cc9f824c
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <WithStyles(ForwardRef(Typography))
+                        className="makeStyles-taskActor-10"
+                        variant="body1"
+                      >
+                        <ForwardRef(Typography)
+                          className="makeStyles-taskActor-10"
+                          classes={
+                            Object {
+                              "alignCenter": "MuiTypography-alignCenter",
+                              "alignJustify": "MuiTypography-alignJustify",
+                              "alignLeft": "MuiTypography-alignLeft",
+                              "alignRight": "MuiTypography-alignRight",
+                              "body1": "MuiTypography-body1",
+                              "body2": "MuiTypography-body2",
+                              "button": "MuiTypography-button",
+                              "caption": "MuiTypography-caption",
+                              "colorError": "MuiTypography-colorError",
+                              "colorInherit": "MuiTypography-colorInherit",
+                              "colorPrimary": "MuiTypography-colorPrimary",
+                              "colorSecondary": "MuiTypography-colorSecondary",
+                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                              "displayBlock": "MuiTypography-displayBlock",
+                              "displayInline": "MuiTypography-displayInline",
+                              "gutterBottom": "MuiTypography-gutterBottom",
+                              "h1": "MuiTypography-h1",
+                              "h2": "MuiTypography-h2",
+                              "h3": "MuiTypography-h3",
+                              "h4": "MuiTypography-h4",
+                              "h5": "MuiTypography-h5",
+                              "h6": "MuiTypography-h6",
+                              "noWrap": "MuiTypography-noWrap",
+                              "overline": "MuiTypography-overline",
+                              "paragraph": "MuiTypography-paragraph",
+                              "root": "MuiTypography-root",
+                              "srOnly": "MuiTypography-srOnly",
+                              "subtitle1": "MuiTypography-subtitle1",
+                              "subtitle2": "MuiTypography-subtitle2",
+                            }
+                          }
+                          variant="body1"
+                        >
+                          <p
+                            className="MuiTypography-root makeStyles-taskActor-10 MuiTypography-body1"
+                          >
+                            [tinyRobot/tinyRobot1]
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                    </div>
+                  </ForwardRef(Typography)>
+                </WithStyles(ForwardRef(Typography))>
+              </div>
+              <WithStyles(ForwardRef(Collapse))
+                className="MuiTreeItem-group"
+                component="ul"
+                in={false}
+                role="group"
+                unmountOnExit={true}
+              >
+                <ForwardRef(Collapse)
+                  className="MuiTreeItem-group"
+                  classes={
+                    Object {
+                      "container": "MuiCollapse-container",
+                      "entered": "MuiCollapse-entered",
+                      "hidden": "MuiCollapse-hidden",
+                      "wrapper": "MuiCollapse-wrapper",
+                      "wrapperInner": "MuiCollapse-wrapperInner",
+                    }
+                  }
+                  component="ul"
+                  in={false}
+                  role="group"
+                  unmountOnExit={true}
+                >
+                  <Transition
+                    addEndListener={[Function]}
+                    appear={false}
+                    enter={true}
+                    exit={true}
+                    in={false}
+                    mountOnEnter={false}
+                    onEnter={[Function]}
+                    onEntered={[Function]}
+                    onEntering={[Function]}
+                    onExit={[Function]}
+                    onExited={[Function]}
+                    onExiting={[Function]}
+                    role="group"
+                    timeout={300}
+                    unmountOnExit={true}
+                  />
+                </ForwardRef(Collapse)>
+              </WithStyles(ForwardRef(Collapse))>
+            </li>
+          </ForwardRef(TreeItem)>
+        </WithStyles(ForwardRef(TreeItem))>
+        <WithStyles(ForwardRef(TreeItem))
+          classes={
+            Object {
+              "expanded": "makeStyles-expanded-5",
+              "label": "makeStyles-active-8 makeStyles-labelContent-4",
+              "root": "makeStyles-treeChildren-3",
+            }
+          }
+          data-component="TreeItem"
+          key="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+          label={
+            <React.Fragment>
+              <ForwardRef(WithStyles)
+                noWrap={true}
+                variant="body1"
+              >
+                <ForwardRef(WithStyles)
+                  onClick={[Function]}
+                >
+                  <UNDEFINED />
+                </ForwardRef(WithStyles)>
+                am8faee9-84ca-41ea-8bb6-8493cc9f8249
+              </ForwardRef(WithStyles)>
+              <ForwardRef(WithStyles)
+                className="makeStyles-taskActor-10"
+                variant="body1"
+              >
+                [tinyRobot/tinyRobot2]
+              </ForwardRef(WithStyles)>
+            </React.Fragment>
+          }
+          nodeId="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+        >
+          <ForwardRef(TreeItem)
+            classes={
+              Object {
+                "content": "MuiTreeItem-content",
+                "expanded": "Mui-expanded makeStyles-expanded-5",
+                "group": "MuiTreeItem-group",
+                "iconContainer": "MuiTreeItem-iconContainer",
+                "label": "MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4",
+                "root": "MuiTreeItem-root makeStyles-treeChildren-3",
+                "selected": "Mui-selected",
+              }
+            }
+            data-component="TreeItem"
+            label={
+              <React.Fragment>
+                <ForwardRef(WithStyles)
+                  noWrap={true}
+                  variant="body1"
+                >
+                  <ForwardRef(WithStyles)
+                    onClick={[Function]}
+                  >
+                    <UNDEFINED />
+                  </ForwardRef(WithStyles)>
+                  am8faee9-84ca-41ea-8bb6-8493cc9f8249
+                </ForwardRef(WithStyles)>
+                <ForwardRef(WithStyles)
+                  className="makeStyles-taskActor-10"
+                  variant="body1"
+                >
+                  [tinyRobot/tinyRobot2]
+                </ForwardRef(WithStyles)>
+              </React.Fragment>
+            }
+            nodeId="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
+          >
+            <li
+              aria-expanded={false}
+              className="MuiTreeItem-root makeStyles-treeChildren-3"
+              data-component="TreeItem"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              role="treeitem"
+              tabIndex={-1}
+            >
+              <div
+                className="MuiTreeItem-content"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+              >
+                <div
+                  className="MuiTreeItem-iconContainer"
+                >
+                  <ForwardRef>
+                    <WithStyles(ForwardRef(SvgIcon))>
+                      <ForwardRef(SvgIcon)
+                        classes={
+                          Object {
+                            "colorAction": "MuiSvgIcon-colorAction",
+                            "colorDisabled": "MuiSvgIcon-colorDisabled",
+                            "colorError": "MuiSvgIcon-colorError",
+                            "colorPrimary": "MuiSvgIcon-colorPrimary",
+                            "colorSecondary": "MuiSvgIcon-colorSecondary",
+                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                            "root": "MuiSvgIcon-root",
+                          }
+                        }
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                          />
+                        </svg>
+                      </ForwardRef(SvgIcon)>
+                    </WithStyles(ForwardRef(SvgIcon))>
+                  </ForwardRef>
+                </div>
+                <WithStyles(ForwardRef(Typography))
+                  className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
+                  component="div"
+                >
+                  <ForwardRef(Typography)
+                    className="MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4"
+                    classes={
+                      Object {
+                        "alignCenter": "MuiTypography-alignCenter",
+                        "alignJustify": "MuiTypography-alignJustify",
+                        "alignLeft": "MuiTypography-alignLeft",
+                        "alignRight": "MuiTypography-alignRight",
+                        "body1": "MuiTypography-body1",
+                        "body2": "MuiTypography-body2",
+                        "button": "MuiTypography-button",
+                        "caption": "MuiTypography-caption",
+                        "colorError": "MuiTypography-colorError",
+                        "colorInherit": "MuiTypography-colorInherit",
+                        "colorPrimary": "MuiTypography-colorPrimary",
+                        "colorSecondary": "MuiTypography-colorSecondary",
+                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                        "displayBlock": "MuiTypography-displayBlock",
+                        "displayInline": "MuiTypography-displayInline",
+                        "gutterBottom": "MuiTypography-gutterBottom",
+                        "h1": "MuiTypography-h1",
+                        "h2": "MuiTypography-h2",
+                        "h3": "MuiTypography-h3",
+                        "h4": "MuiTypography-h4",
+                        "h5": "MuiTypography-h5",
+                        "h6": "MuiTypography-h6",
+                        "noWrap": "MuiTypography-noWrap",
+                        "overline": "MuiTypography-overline",
+                        "paragraph": "MuiTypography-paragraph",
+                        "root": "MuiTypography-root",
+                        "srOnly": "MuiTypography-srOnly",
+                        "subtitle1": "MuiTypography-subtitle1",
+                        "subtitle2": "MuiTypography-subtitle2",
+                      }
+                    }
+                    component="div"
+                  >
+                    <div
+                      className="MuiTypography-root MuiTreeItem-label makeStyles-active-8 makeStyles-labelContent-4 MuiTypography-body1"
+                    >
+                      <WithStyles(ForwardRef(Typography))
+                        noWrap={true}
+                        variant="body1"
+                      >
+                        <ForwardRef(Typography)
+                          classes={
+                            Object {
+                              "alignCenter": "MuiTypography-alignCenter",
+                              "alignJustify": "MuiTypography-alignJustify",
+                              "alignLeft": "MuiTypography-alignLeft",
+                              "alignRight": "MuiTypography-alignRight",
+                              "body1": "MuiTypography-body1",
+                              "body2": "MuiTypography-body2",
+                              "button": "MuiTypography-button",
+                              "caption": "MuiTypography-caption",
+                              "colorError": "MuiTypography-colorError",
+                              "colorInherit": "MuiTypography-colorInherit",
+                              "colorPrimary": "MuiTypography-colorPrimary",
+                              "colorSecondary": "MuiTypography-colorSecondary",
+                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                              "displayBlock": "MuiTypography-displayBlock",
+                              "displayInline": "MuiTypography-displayInline",
+                              "gutterBottom": "MuiTypography-gutterBottom",
+                              "h1": "MuiTypography-h1",
+                              "h2": "MuiTypography-h2",
+                              "h3": "MuiTypography-h3",
+                              "h4": "MuiTypography-h4",
+                              "h5": "MuiTypography-h5",
+                              "h6": "MuiTypography-h6",
+                              "noWrap": "MuiTypography-noWrap",
+                              "overline": "MuiTypography-overline",
+                              "paragraph": "MuiTypography-paragraph",
+                              "root": "MuiTypography-root",
+                              "srOnly": "MuiTypography-srOnly",
+                              "subtitle1": "MuiTypography-subtitle1",
+                              "subtitle2": "MuiTypography-subtitle2",
+                            }
+                          }
+                          noWrap={true}
+                          variant="body1"
+                        >
+                          <p
+                            className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap"
+                          >
+                            <WithStyles(ForwardRef(IconButton))
+                              onClick={[Function]}
+                            >
+                              <ForwardRef(IconButton)
+                                classes={
+                                  Object {
+                                    "colorInherit": "MuiIconButton-colorInherit",
+                                    "colorPrimary": "MuiIconButton-colorPrimary",
+                                    "colorSecondary": "MuiIconButton-colorSecondary",
+                                    "disabled": "Mui-disabled",
+                                    "edgeEnd": "MuiIconButton-edgeEnd",
+                                    "edgeStart": "MuiIconButton-edgeStart",
+                                    "label": "MuiIconButton-label",
+                                    "root": "MuiIconButton-root",
+                                    "sizeSmall": "MuiIconButton-sizeSmall",
+                                  }
+                                }
+                                onClick={[Function]}
+                              >
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  centerRipple={true}
+                                  className="MuiIconButton-root"
+                                  disabled={false}
+                                  focusRipple={true}
+                                  onClick={[Function]}
+                                >
+                                  <ForwardRef(ButtonBase)
+                                    centerRipple={true}
+                                    className="MuiIconButton-root"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    disabled={false}
+                                    focusRipple={true}
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="MuiButtonBase-root MuiIconButton-root"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      tabIndex={0}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="MuiIconButton-label"
+                                      >
+                                        <ForwardRef>
+                                          <WithStyles(ForwardRef(SvgIcon))>
+                                            <ForwardRef(SvgIcon)
+                                              classes={
+                                                Object {
+                                                  "colorAction": "MuiSvgIcon-colorAction",
+                                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                  "colorError": "MuiSvgIcon-colorError",
+                                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                  "root": "MuiSvgIcon-root",
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="MuiSvgIcon-root"
+                                                focusable="false"
+                                                viewBox="0 0 24 24"
+                                              >
+                                                <path
+                                                  d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm-4 29V15l12 9-12 9z"
+                                                  transform="scale(0.5, 0.5)"
+                                                />
+                                              </svg>
+                                            </ForwardRef(SvgIcon)>
+                                          </WithStyles(ForwardRef(SvgIcon))>
+                                        </ForwardRef>
+                                      </span>
+                                      <WithStyles(memo)
+                                        center={true}
+                                      >
+                                        <ForwardRef(TouchRipple)
+                                          center={true}
+                                          classes={
+                                            Object {
+                                              "child": "MuiTouchRipple-child",
+                                              "childLeaving": "MuiTouchRipple-childLeaving",
+                                              "childPulsate": "MuiTouchRipple-childPulsate",
+                                              "ripple": "MuiTouchRipple-ripple",
+                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                              "root": "MuiTouchRipple-root",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="MuiTouchRipple-root"
+                                          >
+                                            <TransitionGroup
+                                              childFactory={[Function]}
+                                              component={null}
+                                              exit={true}
+                                            />
+                                          </span>
+                                        </ForwardRef(TouchRipple)>
+                                      </WithStyles(memo)>
+                                    </button>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(IconButton)>
+                            </WithStyles(ForwardRef(IconButton))>
+                            am8faee9-84ca-41ea-8bb6-8493cc9f8249
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <WithStyles(ForwardRef(Typography))
+                        className="makeStyles-taskActor-10"
+                        variant="body1"
+                      >
+                        <ForwardRef(Typography)
+                          className="makeStyles-taskActor-10"
+                          classes={
+                            Object {
+                              "alignCenter": "MuiTypography-alignCenter",
+                              "alignJustify": "MuiTypography-alignJustify",
+                              "alignLeft": "MuiTypography-alignLeft",
+                              "alignRight": "MuiTypography-alignRight",
+                              "body1": "MuiTypography-body1",
+                              "body2": "MuiTypography-body2",
+                              "button": "MuiTypography-button",
+                              "caption": "MuiTypography-caption",
+                              "colorError": "MuiTypography-colorError",
+                              "colorInherit": "MuiTypography-colorInherit",
+                              "colorPrimary": "MuiTypography-colorPrimary",
+                              "colorSecondary": "MuiTypography-colorSecondary",
+                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                              "displayBlock": "MuiTypography-displayBlock",
+                              "displayInline": "MuiTypography-displayInline",
+                              "gutterBottom": "MuiTypography-gutterBottom",
+                              "h1": "MuiTypography-h1",
+                              "h2": "MuiTypography-h2",
+                              "h3": "MuiTypography-h3",
+                              "h4": "MuiTypography-h4",
+                              "h5": "MuiTypography-h5",
+                              "h6": "MuiTypography-h6",
+                              "noWrap": "MuiTypography-noWrap",
+                              "overline": "MuiTypography-overline",
+                              "paragraph": "MuiTypography-paragraph",
+                              "root": "MuiTypography-root",
+                              "srOnly": "MuiTypography-srOnly",
+                              "subtitle1": "MuiTypography-subtitle1",
+                              "subtitle2": "MuiTypography-subtitle2",
+                            }
+                          }
+                          variant="body1"
+                        >
+                          <p
+                            className="MuiTypography-root makeStyles-taskActor-10 MuiTypography-body1"
+                          >
+                            [tinyRobot/tinyRobot2]
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                    </div>
+                  </ForwardRef(Typography)>
+                </WithStyles(ForwardRef(Typography))>
+              </div>
+              <WithStyles(ForwardRef(Collapse))
+                className="MuiTreeItem-group"
+                component="ul"
+                in={false}
+                role="group"
+                unmountOnExit={true}
+              >
+                <ForwardRef(Collapse)
+                  className="MuiTreeItem-group"
+                  classes={
+                    Object {
+                      "container": "MuiCollapse-container",
+                      "entered": "MuiCollapse-entered",
+                      "hidden": "MuiCollapse-hidden",
+                      "wrapper": "MuiCollapse-wrapper",
+                      "wrapperInner": "MuiCollapse-wrapperInner",
+                    }
+                  }
+                  component="ul"
+                  in={false}
+                  role="group"
+                  unmountOnExit={true}
+                >
+                  <Transition
+                    addEndListener={[Function]}
+                    appear={false}
+                    enter={true}
+                    exit={true}
+                    in={false}
+                    mountOnEnter={false}
+                    onEnter={[Function]}
+                    onEntered={[Function]}
+                    onEntering={[Function]}
+                    onExit={[Function]}
+                    onExited={[Function]}
+                    onExiting={[Function]}
+                    role="group"
+                    timeout={300}
+                    unmountOnExit={true}
+                  />
+                </ForwardRef(Collapse)>
+              </WithStyles(ForwardRef(Collapse))>
+            </li>
+          </ForwardRef(TreeItem)>
+        </WithStyles(ForwardRef(TreeItem))>
+      </ul>
+    </ForwardRef(TreeView)>
+  </WithStyles(ForwardRef(TreeView))>
+</Memo()>
+`;

--- a/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel.test.tsx.snap
+++ b/packages/dashboard/src/components/tests/__snapshots__/task-summary-panel.test.tsx.snap
@@ -1,131 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Matches snapshot 1`] = `
-<WithStyles(ForwardRef(TreeView))
-  className="makeStyles-root-1"
-  defaultCollapseIcon={<UNDEFINED />}
-  defaultExpandIcon={<UNDEFINED />}
-  defaultExpanded={
-    Array [
-      "root",
-    ]
-  }
-  expanded={Array []}
-  onNodeSelect={[Function]}
-  onNodeToggle={[Function]}
-  selected={Array []}
+exports[`Renders correctly Matches snapshot 1`] = `
+<WithStyles(ForwardRef(Typography))
+  component="span"
+  variant="body1"
 >
-  <WithStyles(ForwardRef(TreeItem))
-    classes={
-      Object {
-        "expanded": "makeStyles-expanded-5",
-        "label": "makeStyles-active-8 makeStyles-labelContent-4",
-        "root": "makeStyles-treeChildren-3",
-      }
-    }
-    data-component="TreeItem"
-    key="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
-    label={
-      <React.Fragment>
-        <ForwardRef(WithStyles)
-          noWrap={true}
-          variant="body1"
-        >
-          <ForwardRef(WithStyles)
-            onClick={[Function]}
-          >
-            <UNDEFINED />
-          </ForwardRef(WithStyles)>
-          af8faee9-84ca-41ea-8bb6-8493cc9f824c
-        </ForwardRef(WithStyles)>
-        <ForwardRef(WithStyles)
-          className="makeStyles-taskActor-10"
-          variant="body1"
-        >
-          [tinyRobot/tinyRobot1]
-        </ForwardRef(WithStyles)>
-      </React.Fragment>
-    }
-    nodeId="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
+  <div
+    className="makeStyles-buttonGroupDiv-11"
   >
-    <TaskSummaryPanelItem
-      key="af8faee9-84ca-41ea-8bb6-8493cc9f824c"
-      task={
-        Object {
-          "end_time": Object {
-            "nanosec": 0,
-            "sec": 0,
-          },
-          "start_time": Object {
-            "nanosec": 0,
-            "sec": 0,
-          },
-          "state": 1,
-          "status": "Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
-          "submission_time": Object {
-            "nanosec": 0,
-            "sec": 0,
-          },
-          "task_id": "af8faee9-84ca-41ea-8bb6-8493cc9f824c",
-        }
-      }
+    <TreeButtonGroup
+      disableClear={false}
+      disableReset={false}
+      disableRestore={false}
+      handleClearClick={[Function]}
+      handleResetClick={[Function]}
+      handleRestoreClick={[Function]}
     />
-  </WithStyles(ForwardRef(TreeItem))>
-  <WithStyles(ForwardRef(TreeItem))
-    classes={
-      Object {
-        "expanded": "makeStyles-expanded-5",
-        "label": "makeStyles-active-8 makeStyles-labelContent-4",
-        "root": "makeStyles-treeChildren-3",
-      }
+  </div>
+  <WithStyles(ForwardRef(TreeView))
+    className="makeStyles-root-1"
+    defaultCollapseIcon={<UNDEFINED />}
+    defaultExpandIcon={<UNDEFINED />}
+    defaultExpanded={
+      Array [
+        "root",
+      ]
     }
-    data-component="TreeItem"
-    key="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
-    label={
-      <React.Fragment>
-        <ForwardRef(WithStyles)
-          noWrap={true}
-          variant="body1"
-        >
-          <ForwardRef(WithStyles)
-            onClick={[Function]}
-          >
-            <UNDEFINED />
-          </ForwardRef(WithStyles)>
-          am8faee9-84ca-41ea-8bb6-8493cc9f8249
-        </ForwardRef(WithStyles)>
-        <ForwardRef(WithStyles)
-          className="makeStyles-taskActor-10"
-          variant="body1"
-        >
-          [tinyRobot/tinyRobot2]
-        </ForwardRef(WithStyles)>
-      </React.Fragment>
-    }
-    nodeId="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
-  >
-    <TaskSummaryPanelItem
-      key="am8faee9-84ca-41ea-8bb6-8493cc9f8249"
-      task={
-        Object {
-          "end_time": Object {
-            "nanosec": 0,
-            "sec": 0,
-          },
-          "start_time": Object {
-            "nanosec": 0,
-            "sec": 0,
-          },
-          "state": 1,
-          "status": "Moving [tinyRobot/tinyRobot2]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6",
-          "submission_time": Object {
-            "nanosec": 0,
-            "sec": 0,
-          },
-          "task_id": "am8faee9-84ca-41ea-8bb6-8493cc9f8249",
-        }
-      }
-    />
-  </WithStyles(ForwardRef(TreeItem))>
-</WithStyles(ForwardRef(TreeView))>
+    expanded={Array []}
+    onNodeSelect={[Function]}
+    onNodeToggle={[Function]}
+    selected=""
+  />
+</WithStyles(ForwardRef(Typography))>
 `;

--- a/packages/dashboard/src/components/tests/__snapshots__/tree-button-group.test.tsx.snap
+++ b/packages/dashboard/src/components/tests/__snapshots__/tree-button-group.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Matches snapshot 1`] = `
+<div>
+  <WithStyles(ForwardRef(ButtonGroup))
+    fullWidth={true}
+  >
+    <WithStyles(ForwardRef(Button))
+      id="reset-button"
+      onClick={[Function]}
+    >
+      <RestoreIcon />
+      Reset
+    </WithStyles(ForwardRef(Button))>
+    <WithStyles(ForwardRef(Button))
+      id="clear-button"
+      onClick={[Function]}
+    >
+      <ClearAllIcon />
+      Clear
+    </WithStyles(ForwardRef(Button))>
+    <WithStyles(ForwardRef(Button))
+      id="restore-button"
+      onClick={[Function]}
+    >
+      <RestoreFromTrashIcon />
+      Restore
+    </WithStyles(ForwardRef(Button))>
+  </WithStyles(ForwardRef(ButtonGroup))>
+</div>
+`;

--- a/packages/dashboard/src/components/tests/task-summary-panel-item.test.tsx
+++ b/packages/dashboard/src/components/tests/task-summary-panel-item.test.tsx
@@ -1,0 +1,50 @@
+import { createMount } from '@material-ui/core/test-utils';
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+import { shallow } from 'enzyme';
+import React from 'react';
+import fakeTaskSummary from '../../mock/data/task-summary';
+import { TaskSummaryPanelItem } from '../task-summary-panel-item';
+
+const mount = createMount();
+
+it('Matches snapshot', () => {
+  const task = Object.values(fakeTaskSummary())[0];
+  const root = shallow(<TaskSummaryPanelItem task={task} />);
+  expect(root).toMatchSnapshot();
+  root.unmount();
+});
+
+describe('Components gets correct label on specifics states', () => {
+  let task: RomiCore.TaskSummary;
+  beforeEach(() => {
+    task = Object.values(fakeTaskSummary())[0];
+  });
+
+  test('Correct ACTIVE label', () => {
+    task.state = RomiCore.TaskSummary.STATE_ACTIVE;
+    const root = mount(<TaskSummaryPanelItem task={task} />);
+    expect(root.html()).toContain('ACTIVE');
+    root.unmount();
+  });
+
+  test('Correct QUEUE label', () => {
+    task.state = RomiCore.TaskSummary.STATE_QUEUED;
+    const root = mount(<TaskSummaryPanelItem task={task} />);
+    expect(root.html()).toContain('QUEUE');
+    root.unmount();
+  });
+
+  test('Correct COMPLETED label', () => {
+    task.state = RomiCore.TaskSummary.STATE_COMPLETED;
+    const root = mount(<TaskSummaryPanelItem task={task} />);
+    expect(root.html()).toContain('COMPLETED');
+    root.unmount();
+  });
+
+  test('Correct FAILED label', () => {
+    task.state = RomiCore.TaskSummary.STATE_FAILED;
+    const root = mount(<TaskSummaryPanelItem task={task} />);
+    expect(root.html()).toContain('FAILED');
+    root.unmount();
+  });
+});

--- a/packages/dashboard/src/components/tests/task-summary-panel-item.test.tsx
+++ b/packages/dashboard/src/components/tests/task-summary-panel-item.test.tsx
@@ -14,34 +14,34 @@ it('Matches snapshot', () => {
   root.unmount();
 });
 
-describe('Components gets correct label on specifics states', () => {
+describe('Components gets the correct label on specifics states', () => {
   let task: RomiCore.TaskSummary;
   beforeEach(() => {
     task = Object.values(fakeTaskSummary())[0];
   });
 
-  test('Correct ACTIVE label', () => {
+  test('Shows ACTIVE label', () => {
     task.state = RomiCore.TaskSummary.STATE_ACTIVE;
     const root = mount(<TaskSummaryPanelItem task={task} />);
     expect(root.html()).toContain('ACTIVE');
     root.unmount();
   });
 
-  test('Correct QUEUE label', () => {
+  test('Shows QUEUE label', () => {
     task.state = RomiCore.TaskSummary.STATE_QUEUED;
     const root = mount(<TaskSummaryPanelItem task={task} />);
     expect(root.html()).toContain('QUEUE');
     root.unmount();
   });
 
-  test('Correct COMPLETED label', () => {
+  test('Shows COMPLETED label', () => {
     task.state = RomiCore.TaskSummary.STATE_COMPLETED;
     const root = mount(<TaskSummaryPanelItem task={task} />);
     expect(root.html()).toContain('COMPLETED');
     root.unmount();
   });
 
-  test('Correct FAILED label', () => {
+  test('Shows FAILED label', () => {
     task.state = RomiCore.TaskSummary.STATE_FAILED;
     const root = mount(<TaskSummaryPanelItem task={task} />);
     expect(root.html()).toContain('FAILED');

--- a/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
+++ b/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
@@ -2,7 +2,7 @@ import * as RomiCore from '@osrf/romi-js-core-interfaces';
 import React from 'react';
 import TreeView from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
-import TaskSummaryPanel from '../task-summary-panel';
+import TaskSummaryPanel, { getActorFromStatus } from '../task-summary-panel';
 import fakeTaskSummary from '../../mock/data/task-summary';
 import { createMount } from '@material-ui/core/test-utils';
 import { shallow } from 'enzyme';
@@ -109,4 +109,10 @@ describe('Components gets the correct style on specifics states', () => {
     expect(root.find(TreeItem).html()).toContain('makeStyles-failed');
     root.unmount();
   });
+});
+
+test('Get name of the actor from status', () => {
+  const rawStatus = 'Finding a plan for [tinyRobot/tinyRobot1] to go to [23] | Remaining phases: 6';
+  const actor = getActorFromStatus(rawStatus);
+  expect(actor).toEqual(['[tinyRobot/tinyRobot1]']);
 });

--- a/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
+++ b/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
@@ -5,17 +5,18 @@ import TreeItem from '@material-ui/lab/TreeItem';
 import TaskSummaryPanel from '../task-summary-panel';
 import fakeTaskSummary from '../../mock/data/task-summary';
 import { createMount } from '@material-ui/core/test-utils';
+import { shallow } from 'enzyme';
 
 const mount = createMount();
 
-it('Matches snapshot', () => {
+test('Matches snapshot', () => {
   const tasks = Object.values(fakeTaskSummary());
-  const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+  const root = shallow(<TaskSummaryPanel allTasks={tasks} />);
   expect(root).toMatchSnapshot();
   root.unmount();
 });
 
-it('Renders tree items', () => {
+test('Renders tree items', () => {
   const tasks = Object.values(fakeTaskSummary());
   const root = mount(<TaskSummaryPanel allTasks={tasks} />);
   expect(root.find(TreeView).exists()).toBeTruthy();
@@ -23,14 +24,14 @@ it('Renders tree items', () => {
   root.unmount();
 });
 
-it('Show description below the id if the task has an actor', () => {
+test('Show description below the id if the task has an actor', () => {
   const tasks = Object.values(fakeTaskSummary());
   const root = mount(<TaskSummaryPanel allTasks={tasks} />);
   expect(root.html()).toContain('makeStyles-taskActor');
   root.unmount();
 });
 
-it('Does not show description above the id if the task has an actor', () => {
+test('Does not show description below the id if the task has an actor', () => {
   const task = Object.values(fakeTaskSummary())[0];
   task.status = 'Finished';
   const root = mount(<TaskSummaryPanel allTasks={[task]} />);
@@ -38,7 +39,7 @@ it('Does not show description above the id if the task has an actor', () => {
   root.unmount();
 });
 
-describe('Components gets correct style on specifics states', () => {
+describe('Components gets the correct style on specifics states', () => {
   let task: RomiCore.TaskSummary;
   beforeEach(() => {
     task = Object.values(fakeTaskSummary())[0];

--- a/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
+++ b/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
@@ -9,34 +9,71 @@ import { shallow } from 'enzyme';
 
 const mount = createMount();
 
-test('Matches snapshot', () => {
-  const tasks = Object.values(fakeTaskSummary());
-  const root = shallow(<TaskSummaryPanel allTasks={tasks} />);
-  expect(root).toMatchSnapshot();
-  root.unmount();
+describe('Renders correctly', () => {
+  test('Matches snapshot', () => {
+    const tasks = Object.values(fakeTaskSummary());
+    const root = shallow(<TaskSummaryPanel allTasks={tasks} />);
+    expect(root).toMatchSnapshot();
+    root.unmount();
+  });
+
+  test('Renders tree items', () => {
+    const tasks = Object.values(fakeTaskSummary());
+    const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+    expect(root.find(TreeView).exists()).toBeTruthy();
+    expect(root.find(TreeItem).length).toBe(tasks.length);
+    root.unmount();
+  });
+
+  test('Show description below the id if the task has an actor', () => {
+    const tasks = Object.values(fakeTaskSummary());
+    const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+    expect(root.html()).toContain('makeStyles-taskActor');
+    root.unmount();
+  });
+
+  test('Does not show description below the id if the task has an actor', () => {
+    const task = Object.values(fakeTaskSummary())[0];
+    task.status = 'Finished';
+    const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+    expect(root.html().includes('makeStyles-taskActor')).toBeFalsy();
+    root.unmount();
+  });
 });
 
-test('Renders tree items', () => {
-  const tasks = Object.values(fakeTaskSummary());
-  const root = mount(<TaskSummaryPanel allTasks={tasks} />);
-  expect(root.find(TreeView).exists()).toBeTruthy();
-  expect(root.find(TreeItem).length).toBe(tasks.length);
-  root.unmount();
-});
+describe('Button Bar working correctly', () => {
+  test('should set disabled to true on buttons when empty tasks is provided', () => {
+    const root = mount(<TaskSummaryPanel allTasks={[]} />);
+    expect(root.find('button#clear-button').props().disabled).toEqual(true);
+    expect(root.find('button#reset-button').props().disabled).toEqual(true);
+    expect(root.find('button#restore-button').props().disabled).toEqual(true);
+  });
 
-test('Show description below the id if the task has an actor', () => {
-  const tasks = Object.values(fakeTaskSummary());
-  const root = mount(<TaskSummaryPanel allTasks={tasks} />);
-  expect(root.html()).toContain('makeStyles-taskActor');
-  root.unmount();
-});
+  test('should set disabled to false on buttons when tasks are provided', () => {
+    const tasks = Object.values(fakeTaskSummary());
+    const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+    expect(root.find('button#clear-button').props().disabled).toEqual(false);
+    expect(root.find('button#reset-button').props().disabled).toEqual(false);
+    expect(root.find('button#restore-button').props().disabled).toEqual(false);
+  });
 
-test('Does not show description below the id if the task has an actor', () => {
-  const task = Object.values(fakeTaskSummary())[0];
-  task.status = 'Finished';
-  const root = mount(<TaskSummaryPanel allTasks={[task]} />);
-  expect(root.html().includes('makeStyles-taskActor')).toBeFalsy();
-  root.unmount();
+  test('should empty all current tasks when clear button is clicked', () => {
+    const tasks = Object.values(fakeTaskSummary());
+    const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+    root.find('button#clear-button').simulate('click');
+    expect(root.find('li').length).toEqual(0);
+    root.unmount();
+  });
+
+  test('should render all tasks when restore button is clicked', () => {
+    const task = Object.values(fakeTaskSummary())[0];
+    const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+    // clear all tasks first to ensure empty array
+    root.find('button#clear-button').simulate('click');
+    root.find('button#restore-button').simulate('click');
+    expect(root.find('li').length).toEqual(1);
+    root.unmount();
+  });
 });
 
 describe('Components gets the correct style on specifics states', () => {

--- a/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
+++ b/packages/dashboard/src/components/tests/task-summary-panel.test.tsx
@@ -1,0 +1,74 @@
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+import React from 'react';
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem from '@material-ui/lab/TreeItem';
+import TaskSummaryPanel from '../task-summary-panel';
+import fakeTaskSummary from '../../mock/data/task-summary';
+import { createMount } from '@material-ui/core/test-utils';
+
+const mount = createMount();
+
+it('Matches snapshot', () => {
+  const tasks = Object.values(fakeTaskSummary());
+  const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+  expect(root).toMatchSnapshot();
+  root.unmount();
+});
+
+it('Renders tree items', () => {
+  const tasks = Object.values(fakeTaskSummary());
+  const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+  expect(root.find(TreeView).exists()).toBeTruthy();
+  expect(root.find(TreeItem).length).toBe(tasks.length);
+  root.unmount();
+});
+
+it('Show description below the id if the task has an actor', () => {
+  const tasks = Object.values(fakeTaskSummary());
+  const root = mount(<TaskSummaryPanel allTasks={tasks} />);
+  expect(root.html()).toContain('makeStyles-taskActor');
+  root.unmount();
+});
+
+it('Does not show description above the id if the task has an actor', () => {
+  const task = Object.values(fakeTaskSummary())[0];
+  task.status = 'Finished';
+  const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+  expect(root.html().includes('makeStyles-taskActor')).toBeFalsy();
+  root.unmount();
+});
+
+describe('Components gets correct style on specifics states', () => {
+  let task: RomiCore.TaskSummary;
+  beforeEach(() => {
+    task = Object.values(fakeTaskSummary())[0];
+  });
+
+  test('active style is applied ', () => {
+    task.state = RomiCore.TaskSummary.STATE_ACTIVE;
+    const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+    expect(root.find(TreeItem).html()).toContain('makeStyles-active');
+    root.unmount();
+  });
+
+  test('queue style is applied', () => {
+    task.state = RomiCore.TaskSummary.STATE_QUEUED;
+    const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+    expect(root.find(TreeItem).html()).toContain('makeStyles-queued');
+    root.unmount();
+  });
+
+  test('completed style is applied', () => {
+    task.state = RomiCore.TaskSummary.STATE_COMPLETED;
+    const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+    expect(root.find(TreeItem).html()).toContain('makeStyles-completed');
+    root.unmount();
+  });
+
+  test('failed style is applied', () => {
+    task.state = RomiCore.TaskSummary.STATE_FAILED;
+    const root = mount(<TaskSummaryPanel allTasks={[task]} />);
+    expect(root.find(TreeItem).html()).toContain('makeStyles-failed');
+    root.unmount();
+  });
+});

--- a/packages/dashboard/src/components/tests/tree-button-group.test.tsx
+++ b/packages/dashboard/src/components/tests/tree-button-group.test.tsx
@@ -1,0 +1,37 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import { TreeButtonGroup } from '../tree-button-group';
+
+test('Matches snapshot', () => {
+  const root = shallow(<TreeButtonGroup />);
+  expect(root).toMatchSnapshot();
+});
+
+test('It disabled buttons', () => {
+  const root = mount(
+    <TreeButtonGroup disableClear={true} disableReset={true} disableRestore={true} />,
+  );
+  expect(root.find('button#clear-button').props().disabled).toEqual(true);
+  expect(root.find('button#reset-button').props().disabled).toEqual(true);
+  expect(root.find('button#restore-button').props().disabled).toEqual(true);
+});
+
+test('It executes callbacks correctly', () => {
+  const handleResetClick = jest.fn();
+  const handleClearClick = jest.fn();
+  const handleRestoreClick = jest.fn();
+  const root = mount(
+    <TreeButtonGroup
+      handleResetClick={handleResetClick}
+      handleClearClick={handleClearClick}
+      handleRestoreClick={handleRestoreClick}
+    />,
+  );
+  root.find('button#clear-button').simulate('click');
+  root.find('button#reset-button').simulate('click');
+  root.find('button#restore-button').simulate('click');
+
+  expect(handleResetClick).toHaveBeenCalledTimes(1);
+  expect(handleClearClick).toHaveBeenCalledTimes(1);
+  expect(handleRestoreClick).toHaveBeenCalledTimes(1);
+});

--- a/packages/dashboard/src/components/tree-button-group.tsx
+++ b/packages/dashboard/src/components/tree-button-group.tsx
@@ -5,31 +5,32 @@ import RestoreFromTrashIcon from '@material-ui/icons/RestoreFromTrash';
 import React from 'react';
 
 export interface TreeButtonGroupProps {
-  disableReset: boolean;
-  disableClear: boolean;
-  disableRestore: boolean;
-  handlResetClick?: () => void;
+  disableReset?: boolean;
+  disableClear?: boolean;
+  disableRestore?: boolean;
+  handleResetClick?: () => void;
   handleClearClick?: () => void;
   handleRestoreClick?: () => void;
+  fullWidth: boolean;
 }
 
-// className={classes.buttonGroupDiv}
 export const TreeButtonGroup = (props: TreeButtonGroupProps) => {
   const {
     disableReset,
     disableClear,
     disableRestore,
-    handlResetClick,
+    handleResetClick,
     handleClearClick,
     handleRestoreClick,
+    fullWidth = true,
   } = props;
   return (
     <div>
-      <ButtonGroup fullWidth>
+      <ButtonGroup fullWidth={fullWidth}>
         <Button
           id="reset-button"
           disabled={disableReset}
-          onClick={() => handlResetClick && handlResetClick()}
+          onClick={() => handleResetClick && handleResetClick()}
         >
           <RestoreIcon />
           Reset

--- a/packages/dashboard/src/components/tree-button-group.tsx
+++ b/packages/dashboard/src/components/tree-button-group.tsx
@@ -11,7 +11,7 @@ export interface TreeButtonGroupProps {
   handleResetClick?: () => void;
   handleClearClick?: () => void;
   handleRestoreClick?: () => void;
-  fullWidth: boolean;
+  fullWidth?: boolean;
 }
 
 export const TreeButtonGroup = (props: TreeButtonGroupProps) => {

--- a/packages/dashboard/src/components/tree-button-group.tsx
+++ b/packages/dashboard/src/components/tree-button-group.tsx
@@ -1,0 +1,56 @@
+import { Button, ButtonGroup } from '@material-ui/core';
+import ClearAllIcon from '@material-ui/icons/ClearAll';
+import RestoreIcon from '@material-ui/icons/Restore';
+import RestoreFromTrashIcon from '@material-ui/icons/RestoreFromTrash';
+import React from 'react';
+
+export interface TreeButtonGroupProps {
+  disableReset: boolean;
+  disableClear: boolean;
+  disableRestore: boolean;
+  handlResetClick?: () => void;
+  handleClearClick?: () => void;
+  handleRestoreClick?: () => void;
+}
+
+// className={classes.buttonGroupDiv}
+export const TreeButtonGroup = (props: TreeButtonGroupProps) => {
+  const {
+    disableReset,
+    disableClear,
+    disableRestore,
+    handlResetClick,
+    handleClearClick,
+    handleRestoreClick,
+  } = props;
+  return (
+    <div>
+      <ButtonGroup fullWidth>
+        <Button
+          id="reset-button"
+          disabled={disableReset}
+          onClick={() => handlResetClick && handlResetClick()}
+        >
+          <RestoreIcon />
+          Reset
+        </Button>
+        <Button
+          id="clear-button"
+          disabled={disableClear}
+          onClick={() => handleClearClick && handleClearClick()}
+        >
+          <ClearAllIcon />
+          Clear
+        </Button>
+        <Button
+          id="restore-button"
+          disabled={disableRestore}
+          onClick={() => handleRestoreClick && handleRestoreClick()}
+        >
+          <RestoreFromTrashIcon />
+          Restore
+        </Button>
+      </ButtonGroup>
+    </div>
+  );
+};

--- a/packages/dashboard/src/managers/task-manager.ts
+++ b/packages/dashboard/src/managers/task-manager.ts
@@ -23,31 +23,6 @@ export default class TaskManager extends EventEmitter<Events> {
     this._subscriptions.forEach((sub) => sub.unsubscribe());
   }
 
-  static getActorFromStatus(status: string) {
-    // Gets the name of the robot if it has any
-    // eslint-disable-next-line
-    return status.match(/\[[A-Za-z]([a-zA-Z0-9\/]){3,}\]+/gi);
-  }
-
-  static formatStatus(status: string) {
-    return status.split('|');
-  }
-
-  static getStateLabel(state: number): string {
-    switch (state) {
-      case RomiCore.TaskSummary.STATE_QUEUED:
-        return 'QUEUED';
-      case RomiCore.TaskSummary.STATE_ACTIVE:
-        return 'ACTIVE';
-      case RomiCore.TaskSummary.STATE_COMPLETED:
-        return 'COMPLETED';
-      case RomiCore.TaskSummary.STATE_FAILED:
-        return 'FAILED';
-      default:
-        return 'UNKNOWN';
-    }
-  }
-
   private _tasks: Record<string, RomiCore.TaskSummary> = {};
   private _subscriptions: RomiCore.Subscription[] = [];
 }

--- a/packages/dashboard/src/managers/task-manager.ts
+++ b/packages/dashboard/src/managers/task-manager.ts
@@ -5,7 +5,7 @@ type Events = {
   updated: [];
 };
 
-enum taskState {
+export enum TaskState {
   STATE_QUEUED = 0,
   STATE_ACTIVE,
   STATE_COMPLETED,
@@ -31,19 +31,24 @@ export default class TaskManager extends EventEmitter<Events> {
     this._subscriptions.forEach((sub) => sub.unsubscribe());
   }
 
-  static formatStatus(status: string): string[] {
-    return status.split('|');
+  static formatStatus(status: string) {
+    const statusSplited = status.split('|');
+    const action = statusSplited[0];
+    const remainingPhases1 = statusSplited[1];
+    const remainingPhases2 = statusSplited[2];
+    const statusLabel = statusSplited[0].split(':')[0];
+    return { action, remainingPhases1, remainingPhases2, statusLabel };
   }
 
   static getStateLabel(state: number): string {
     switch (state) {
-      case taskState.STATE_QUEUED:
+      case TaskState.STATE_QUEUED:
         return 'QUEUED';
-      case taskState.STATE_ACTIVE:
+      case TaskState.STATE_ACTIVE:
         return 'ACTIVE';
-      case taskState.STATE_COMPLETED:
+      case TaskState.STATE_COMPLETED:
         return 'COMPLETED';
-      case taskState.STATE_FAILED:
+      case TaskState.STATE_FAILED:
         return 'FAILED';
       default:
         return 'UNKNOWN';

--- a/packages/dashboard/src/managers/task-manager.ts
+++ b/packages/dashboard/src/managers/task-manager.ts
@@ -5,16 +5,8 @@ type Events = {
   updated: [];
 };
 
-export enum TaskState {
-  STATE_QUEUED = 0,
-  STATE_ACTIVE,
-  STATE_COMPLETED,
-  STATE_FAILED,
-}
-
 export default class TaskManager extends EventEmitter<Events> {
   tasks(): RomiCore.TaskSummary[] {
-    console.log(this._tasks);
     return Array.from(Object.values(this._tasks));
   }
 
@@ -31,24 +23,24 @@ export default class TaskManager extends EventEmitter<Events> {
     this._subscriptions.forEach((sub) => sub.unsubscribe());
   }
 
+  static getActorFromStatus(status: string) {
+    // Gets the name of the robot if it has any
+    return status.match(/\[[A-Za-z]([a-zA-Z0-9\/]){3,}\]+/gi);
+  }
+
   static formatStatus(status: string) {
-    const statusSplited = status.split('|');
-    const action = statusSplited[0];
-    const remainingPhases1 = statusSplited[1];
-    const remainingPhases2 = statusSplited[2];
-    const statusLabel = statusSplited[0].split(':')[0];
-    return { action, remainingPhases1, remainingPhases2, statusLabel };
+    return status.split('|');
   }
 
   static getStateLabel(state: number): string {
     switch (state) {
-      case TaskState.STATE_QUEUED:
+      case RomiCore.TaskSummary.STATE_QUEUED:
         return 'QUEUED';
-      case TaskState.STATE_ACTIVE:
+      case RomiCore.TaskSummary.STATE_ACTIVE:
         return 'ACTIVE';
-      case TaskState.STATE_COMPLETED:
+      case RomiCore.TaskSummary.STATE_COMPLETED:
         return 'COMPLETED';
-      case TaskState.STATE_FAILED:
+      case RomiCore.TaskSummary.STATE_FAILED:
         return 'FAILED';
       default:
         return 'UNKNOWN';

--- a/packages/dashboard/src/managers/task-manager.ts
+++ b/packages/dashboard/src/managers/task-manager.ts
@@ -1,0 +1,55 @@
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+import EventEmitter from 'eventemitter3';
+
+type Events = {
+  updated: [];
+};
+
+enum taskState {
+  STATE_QUEUED = 0,
+  STATE_ACTIVE,
+  STATE_COMPLETED,
+  STATE_FAILED,
+}
+
+export default class TaskManager extends EventEmitter<Events> {
+  tasks(): RomiCore.TaskSummary[] {
+    console.log(this._tasks);
+    return Array.from(Object.values(this._tasks));
+  }
+
+  startSubscription(transport: RomiCore.Transport) {
+    this._subscriptions.push(
+      transport.subscribe(RomiCore.taskSummaries, (taskSummary) => {
+        this._tasks[taskSummary.task_id] = taskSummary;
+        this.emit('updated');
+      }),
+    );
+  }
+
+  stopAllSubscriptions(): void {
+    this._subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  static formatStatus(status: string): string[] {
+    return status.split('|');
+  }
+
+  static getStateLabel(state: number): string {
+    switch (state) {
+      case taskState.STATE_QUEUED:
+        return 'QUEUED';
+      case taskState.STATE_ACTIVE:
+        return 'ACTIVE';
+      case taskState.STATE_COMPLETED:
+        return 'COMPLETED';
+      case taskState.STATE_FAILED:
+        return 'FAILED';
+      default:
+        return 'UNKNOWN';
+    }
+  }
+
+  private _tasks: Record<string, RomiCore.TaskSummary> = {};
+  private _subscriptions: RomiCore.Subscription[] = [];
+}

--- a/packages/dashboard/src/managers/task-manager.ts
+++ b/packages/dashboard/src/managers/task-manager.ts
@@ -25,6 +25,7 @@ export default class TaskManager extends EventEmitter<Events> {
 
   static getActorFromStatus(status: string) {
     // Gets the name of the robot if it has any
+    // eslint-disable-next-line
     return status.match(/\[[A-Za-z]([a-zA-Z0-9\/]){3,}\]+/gi);
   }
 

--- a/packages/dashboard/src/managers/tests/task-manager.test.ts
+++ b/packages/dashboard/src/managers/tests/task-manager.test.ts
@@ -1,7 +1,0 @@
-import TaskManager from '../task-manager';
-
-test('Get name of the robot from status', () => {
-  const rawStatus = 'Finding a plan for [tinyRobot/tinyRobot1] to go to [23] | Remaining phases: 6';
-  const actor = TaskManager.getActorFromStatus(rawStatus);
-  expect(actor).toEqual(['[tinyRobot/tinyRobot1]']);
-});

--- a/packages/dashboard/src/managers/tests/task-manager.test.ts
+++ b/packages/dashboard/src/managers/tests/task-manager.test.ts
@@ -1,8 +1,7 @@
 import TaskManager from '../task-manager';
 
-test('Status is been formatted correctly', () => {
+test('Get name of the robot from status', () => {
   const rawStatus = 'Finding a plan for [tinyRobot/tinyRobot1] to go to [23] | Remaining phases: 6';
-  // "Moving [tinyRobot/tinyRobot1]: ( 10.2479 -3.09206  1.16262) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6"
-  const status = TaskManager.formatStatus(rawStatus);
-  // expect(status)
+  const actor = TaskManager.getActorFromStatus(rawStatus);
+  expect(actor).toBe('[tinyRobot/tinyRobot1]');
 });

--- a/packages/dashboard/src/managers/tests/task-manager.test.ts
+++ b/packages/dashboard/src/managers/tests/task-manager.test.ts
@@ -1,0 +1,8 @@
+import TaskManager from '../task-manager';
+
+test('Status is been formatted correctly', () => {
+  const rawStatus = 'Finding a plan for [tinyRobot/tinyRobot1] to go to [23] | Remaining phases: 6';
+  // "Moving [tinyRobot/tinyRobot1]: ( 10.2479 -3.09206  1.16262) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6"
+  const status = TaskManager.formatStatus(rawStatus);
+  // expect(status)
+});

--- a/packages/dashboard/src/managers/tests/task-manager.test.ts
+++ b/packages/dashboard/src/managers/tests/task-manager.test.ts
@@ -3,5 +3,5 @@ import TaskManager from '../task-manager';
 test('Get name of the robot from status', () => {
   const rawStatus = 'Finding a plan for [tinyRobot/tinyRobot1] to go to [23] | Remaining phases: 6';
   const actor = TaskManager.getActorFromStatus(rawStatus);
-  expect(actor).toBe('[tinyRobot/tinyRobot1]');
+  expect(actor).toEqual(['[tinyRobot/tinyRobot1]']);
 });

--- a/packages/dashboard/src/mock/data/task-summary.ts
+++ b/packages/dashboard/src/mock/data/task-summary.ts
@@ -14,7 +14,7 @@ export default function fakeTaskSummary(): Record<string, RomiCore.TaskSummary> 
     'am8faee9-84ca-41ea-8bb6-8493cc9f8249': {
       end_time: { sec: 0, nanosec: 0 },
       start_time: { sec: 0, nanosec: 0 },
-      state: 1,
+      state: 0,
       status:
         'Moving [tinyRobot/tinyRobot2]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6',
       submission_time: { sec: 0, nanosec: 0 },

--- a/packages/dashboard/src/mock/data/task-summary.ts
+++ b/packages/dashboard/src/mock/data/task-summary.ts
@@ -1,0 +1,15 @@
+import * as RomiCore from '@osrf/romi-js-core-interfaces';
+
+export default function fakeTaskSummary(): Record<string, RomiCore.TaskSummary> {
+  return {
+    'af8faee9-84ca-41ea-8bb6-8493cc9f824c': {
+      end_time: { sec: 0, nanosec: 0 },
+      start_time: { sec: 0, nanosec: 0 },
+      state: 1,
+      status:
+        'Moving [tinyRobot/tinyRobot1]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6',
+      submission_time: { sec: 0, nanosec: 0 },
+      task_id: 'af8faee9-84ca-41ea-8bb6-8493cc9f824c',
+    },
+  };
+}

--- a/packages/dashboard/src/mock/data/task-summary.ts
+++ b/packages/dashboard/src/mock/data/task-summary.ts
@@ -11,5 +11,14 @@ export default function fakeTaskSummary(): Record<string, RomiCore.TaskSummary> 
       submission_time: { sec: 0, nanosec: 0 },
       task_id: 'af8faee9-84ca-41ea-8bb6-8493cc9f824c',
     },
+    'am8faee9-84ca-41ea-8bb6-8493cc9f8249': {
+      end_time: { sec: 0, nanosec: 0 },
+      start_time: { sec: 0, nanosec: 0 },
+      state: 1,
+      status:
+        'Moving [tinyRobot/tinyRobot2]: ( 9.81228 -6.98942 -3.12904) -> ( 6.26403 -3.51569  1.16864) | Remaining phases: 1 | Remaining phases: 6',
+      submission_time: { sec: 0, nanosec: 0 },
+      task_id: 'am8faee9-84ca-41ea-8bb6-8493cc9f8249',
+    },
   };
 }

--- a/packages/dashboard/src/mock/fake-transport.ts
+++ b/packages/dashboard/src/mock/fake-transport.ts
@@ -5,6 +5,7 @@ import fakeDispenserStates from './data/dispenser-states';
 import fakeDoorStates from './data/door-states';
 import fakeFleets from './data/fleets';
 import fakeLiftStates from './data/lift-states';
+import fakeTaskSummary from './data/task-summary';
 
 const debug = Debug('FakeTransport');
 
@@ -71,6 +72,17 @@ export class FakeTransport extends RomiCore.TransportEvents implements RomiCore.
           for (const state of Object.values(dispenserStates)) {
             debug('publishing dispenser state, %s', state.guid);
             cb(state as Message);
+          }
+        }, 1000);
+        break;
+      }
+
+      case RomiCore.taskSummaries: {
+        const taskSummaries = fakeTaskSummary();
+        timer = window.setInterval(() => {
+          for (const task of Object.values(taskSummaries)) {
+            debug('publishing task, %s', task.task_id);
+            cb(task as Message);
           }
         }, 1000);
         break;


### PR DESCRIPTION
## What's new
pre-requisite https://github.com/osrf/romi-dashboard/pull/153 [Merged]

fixes #

* Created a taskSummary windows on the omnipannel with a tree structure, 
* Subscribed to TaskSummary
* Created mock
* Added a pause button but it is not implemented yet.
* Add unit tests
* Add e2e tests

![image](https://user-images.githubusercontent.com/11761240/97365493-891c1200-1884-11eb-9b27-2d9c81dd17f4.png)





## Self-checks

- [X] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [X] I added unit-tests for new components
- [X] I tried testing edge cases
- [X] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

If we will keep the tree button group component I'll refactor the negotiation panel in another PR