### PR TITLE
Added description to the `fixes` line

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## What's new
 
-fixes #
+fixes # [related issue, if exist]
 
 [Describe your changes]
 


### PR DESCRIPTION
## What's new
Hey guys, Tagging you all for awareness. =) 

fixes #146 

Added description to the `fixes` line. The idea is to place a GH issue (if exists of course) on fixes. E.g. when this PR is merged the issue #146 should be close automatically. If you don't have a related issue you can either remove that line or leave it blank.

## Self-checks
Does not apply

## Discussion
Is that description ok?