### PR TITLE
Renamed the remote from `origin` to `resources`

### DIFF
--- a/packages/dashboard/scripts/setup/get-icons.js
+++ b/packages/dashboard/scripts/setup/get-icons.js
@@ -102,6 +102,8 @@ class IconManager extends IconManagerBase {
   };
 
   cloneSpecificFolder = () => {
+    // Safeguard in case the tmp is not deleted and already have a remote defined
+    this.removeTmpFolder();
     this.createTmpFolder();
     exec(`git --version`, (error, stdout, stderr) => {
       if (error) {

--- a/packages/dashboard/scripts/setup/get-icons.js
+++ b/packages/dashboard/scripts/setup/get-icons.js
@@ -72,7 +72,7 @@ class SparseCheckoutGitV217 extends IconManagerBase {
   }
 
   execute = () => {
-    execSync(`git init && git remote add -f origin "${this.resourcesData.repoUrl}"`, {
+    execSync(`git init && git remote add -f resources "${this.resourcesData.repoUrl}"`, {
       stdio: [0, 1, 2],
       cwd: path.resolve(__dirname, this.tempFolderLocation),
     });
@@ -83,7 +83,7 @@ class SparseCheckoutGitV217 extends IconManagerBase {
         cwd: path.resolve(__dirname, this.tempFolderLocation),
       },
     );
-    execSync(`git pull --depth=1 origin ${this.resourcesData.branch}`, {
+    execSync(`git pull --depth=1 resources ${this.resourcesData.branch}`, {
       stdio: [0, 1, 2],
       cwd: path.resolve(__dirname, this.tempFolderLocation),
     });


### PR DESCRIPTION
## What's new

fixes #148

* Using the `origin` name creates problems if people already have a local remote name defined as origin. Renamed remote repo from `origin` to `resources`
* Added a safeguard in case the tmp is in an inconsistent state.

## Self-checks
Does not apply
