### PR TITLE
add npm debug log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+npm-debug.log


### PR DESCRIPTION
## What's new

I added a new file `npm-debug-log` to exclude in `.gitignore`.

fixes # [related issue, if exist]

This is to exclude committing the `npm-debug-log` that is generated when running operations from npm commands in `react-components`.

[Describe your changes]

A line in the `.gitignore` file at the root folder to exclude `npm-debug.log`.

## Self-checks

- [x] I'm familiar with and follow this [ Typescript guideline](https://basarat.gitbook.io/typescript/styleguide)
- [ ] I added unit-tests for new components
- [x] I tried testing edge cases
- [ ] I tested the behavior of the components that interact with the backend, with an e2e test

## Discussion

[Questions for reviewers]